### PR TITLE
Use metadata API endpoint for initial lookup tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ clean:
 
 dev-requirements:
 	pip3 install -r dev-requirements.txt
+
+dev-install: build
+	pip3 uninstall -y dbt-metabase && pip3 install dist/dbt_metabase-*-py3-none-any.whl

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -236,15 +236,15 @@ class MetabaseClient:
 
         metadata = self.api('get', f'/api/database/{database_id}/metadata')
         for table in metadata.get('tables', []):
+            if table['schema'].upper() != schema.upper():
+                continue
+
             table_name = table['name'].upper()
             table_lookup[table_name] = table
 
             table_field_lookup = {}
 
             for field in table.get('fields', []):
-                if field['schema'].upper() != schema.upper():
-                    continue
-
                 field_name = field['name'].upper()
                 table_field_lookup[field_name] = field
 

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -93,7 +93,7 @@ class MetabaseClient:
             bool -- True if schema compatible with models, false otherwise.
         """
 
-        field_lookup = self.build_field_lookup(database_id, schema)
+        _, field_lookup = self.build_metadata_lookups(database_id, schema)
 
         for model in models:
             model_name = model['name'].upper()
@@ -145,9 +145,10 @@ class MetabaseClient:
 
         table_id = api_table['id']
         if api_table['description'] != model['description']:
-            api_table['description'] = model['description']
-
-            self.api('put', f'/api/table/{table_id}', json=api_table)
+            # Update with new values
+            self.api('put', f'/api/table/{table_id}', json={
+                'description': model['description']
+            })
             logging.info("Updated table %s successfully", model_name)
         else:
             logging.info("Table %s is up-to-date", model_name)
@@ -192,12 +193,13 @@ class MetabaseClient:
                 api_field['special_type'] != column.get('special_type') or \
                 api_field['visibility_type'] != column.get('visibility_type') or \
                 api_field['fk_target_field_id'] != fk_target_field_id:
-            api_field['description'] = column.get('description')
-            api_field['special_type'] = column.get('special_type')
-            api_field['visibility_type'] = column.get('visibility_type')
-            api_field['fk_target_field_id'] = fk_target_field_id
-
-            self.api('put', f'/api/field/{field_id}', json=api_field)
+            # Update with new values
+            self.api('put', f'/api/field/{field_id}', json={
+                'description': column.get('description'),
+                'special_type': column.get('special_type'),
+                'visibility_type': column.get('visibility_type'),
+                'fk_target_field_id': fk_target_field_id
+            })
             logging.info("Updated field %s.%s successfully", model_name, column_name)
         else:
             logging.info("Field %s.%s is up-to-date", model_name, column_name)


### PR DESCRIPTION
Replace `/tables` and `/fields` API calls with one `/metadata` call for initial lookup tables.

Discussion: https://github.com/gouline/dbt-metabase/issues/4