### PR TITLE
Include hidden tables in Metabase

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -241,7 +241,11 @@ class MetabaseClient:
         table_lookup = {}
         field_lookup = {}
 
-        metadata = self.api('get', f'/api/database/{database_id}/metadata')
+        metadata = self.api(
+            'get',
+            f'/api/database/{database_id}/metadata',
+            params=dict(include_hidden=True)
+        )
         for table in metadata.get('tables', []):
             table_schema = 'public' if table['schema'] is None else table['schema']
             if table_schema.upper() != schema.upper():


### PR DESCRIPTION
The tables can be hidden/unhidden anytime, so it's useful to have
the docs always in sync.

Also, we currently fail if any tables in dbt doesn't exist in Metabase.
So, without this change, dbtmetabase doesn't work for instances that
have hidden tables.