### PR TITLE
Add flag to ignore undefined properties

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -65,7 +65,7 @@ def main(args: list = None):
     parser.add_argument('--sync_timeout', metavar='SECS', type=int, default=30, help="synchronization timeout (in secs)")
     parser.add_argument('--includes', metavar='MODELS', nargs='*', default=[], help="model names to limit processing to")
     parser.add_argument('--excludes', metavar='MODELS', nargs='*', default=[], help="model names to exclude")
-    parser.add_argument('--ignore_undefined', metavar='IGNORE_NONE', type=bool, default=False, help="ignore properties not defined in dbt models")
+    parser.add_argument('--ignore_undefined', metavar='IGNORE_UNDEFINED', type=bool, default=False, help="ignore properties not defined in dbt models")
     parsed = parser.parse_args(args=args)
 
     if parsed.command == 'export':


### PR DESCRIPTION
Add the `ignore_undefined` flag to ignore properties that are not
defined in the dbt file. If the `ignore_undefined` flag is set
the JSON payload sent to the api request in Metabase will
contain only properties that are not None in the dbt file.

Example:
- ignore_undefined = true and 'special_type' is None:
	Metabase special type won't be changed
- ignore_undefined = false and 'special_type' is None:
	Metabase special type will be removed