### PR TITLE
Rename `special_type` to `semantic_type`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Model synchronization from `dbt`_ to `Metabase`_.
 
 If dbt is your source of truth for database schemas and you use Metabase as
 your analytics tool, dbt-metabase can propagate table relationships, model and
-column descriptions and special types (e.g. currency, category, URL) to your
+column descriptions and semantic types (e.g. currency, category, URL) to your
 Metabase data model.
 
 Requirements
@@ -80,8 +80,8 @@ Check your Metabase instance by going into Settings > Admin > Data Model, you
 will notice that ``ID`` in ``STG_USERS`` is now marked as "Entity Key" and
 ``GROUP_ID`` is marked as "Foreign Key" pointing to ``ID`` in ``STG_GROUPS``.
 
-Special Types
--------------
+Semantic Types
+--------------
 
 Now that we have primary and foreign keys, let's tell Metabase that ``email``
 column contains email addresses.
@@ -93,12 +93,12 @@ Change the ``email`` column as follows:
     - name: email
       description: User's email address.
       meta:
-        metabase.special_type: type/Email
+        metabase.semantic_type: type/Email
 
 Once you run ``dbt-metabase export`` again, you will notice that ``EMAIL`` is
 now marked as "Email".
 
-Here is the list of special types currently accepted by Metabase:
+Here is the list of semantic types (formerly known as special types) currently accepted by Metabase:
 
 * ``type/PK``
 * ``type/FK``
@@ -153,7 +153,7 @@ If you notice new ones, please submit a PR to update this readme.
 Visibility Types
 ----------------
 
-In addition to special types, you can optionally specify visibility for each
+In addition to semantic types, you can optionally specify visibility for each
 field. This affects whether or not they are displayed in the Metabase UI.
 
 Here is how you would hide that same email:
@@ -163,7 +163,7 @@ Here is how you would hide that same email:
     - name: email
       description: User's email address.
       meta:
-        metabase.special_type: type/Email
+        metabase.semantic_type: type/Email
         metabase.visibility_type: sensitive
 
 Here are the visibility types supported by Metabase:

--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -4,7 +4,10 @@ import re
 from pathlib import Path
 
 # Allowed metabase.* fields
-_META_FIELDS = ["special_type", "visibility_type"]
+_META_FIELDS = [
+    "semantic_type",
+    "visibility_type",
+]
 
 
 class DbtReader:
@@ -82,7 +85,7 @@ class DbtReader:
             if isinstance(test, dict):
                 if "relationships" in test:
                     relationships = test["relationships"]
-                    mb_column["special_type"] = "type/FK"
+                    mb_column["semantic_type"] = "type/FK"
                     mb_column["fk_target_table"] = self.parse_ref(
                         relationships["to"]
                     ).upper()
@@ -93,6 +96,14 @@ class DbtReader:
             for field in _META_FIELDS:
                 if f"metabase.{field}" in meta:
                     mb_column[field] = meta[f"metabase.{field}"]
+
+            # TODO: remove deprecation in future
+            if "metabase.special_type" in meta:
+                logging.warning(
+                    "DEPRECATION: metabase.special_type is deprecated and will be removed, use metabase.semantic_type instead"
+                )
+                if "semantic_type" not in mb_column:
+                    mb_column["semantic_type"] = meta["metabase.special_type"]
 
         return mb_column
 


### PR DESCRIPTION
Metabase 0.39.0 renamed `special_type` to `semantic_type`. This PR renames it accordingly:

- dbt meta field `metabase.special_type` is now deprecated, use `metabase.semantic_type` instead (will be removed)
- exporter checks API response for `special_type`/`semantic_type` and applies whichever one is present for backwards compatibility with earlier Metabase versions