### PR TITLE
Added support for aliased models and source blocks

### DIFF
--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -44,7 +44,7 @@ class DbtReader:
                 schema = yaml.safe_load(stream)
                 if schema is None:
                     logging.warn(
-                        "Skipping empty/invalid YML file at %s", 
+                        "Skipping empty or invalid YAML: %s", 
                         path
                     )
                     continue

--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -36,6 +36,10 @@ class DbtReader:
         mb_models = []
 
         for path in (Path(self.project_path) / "models").rglob("*.yml"):
+            logging.info(
+                "Processing model: %s", 
+                path
+            )
             with open(path, "r") as stream:
                 schema = yaml.safe_load(stream)
                 if schema is None:

--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -71,7 +71,7 @@ class DbtReader:
             mb_columns.append(self.read_column(column))
 
         return {
-            "name": model.get('identifier', model["name"]).upper(),
+            "name": model.get("identifier", model["name"]).upper(),
             "description": model.get("description"),
             "columns": mb_columns,
         }

--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -36,21 +36,22 @@ class DbtReader:
         mb_models = []
 
         for path in (Path(self.project_path) / "models").rglob("*.yml"):
-            print(path)
+            logging.info(path)
             with open(path, "r") as stream:
                 schema = yaml.safe_load(stream)
                 if schema is None:
                     continue
                 for model in schema.get("models", []):
-                    name = model.get('identifier', model["name"])
+                    name = model.get("identifier", model["name"])
                     print("MODEL", name)
                     if (not includes or name in includes) and (name not in excludes):
                         mb_models.append(self.read_model(model))
-                for source in schema.get("sources", [{}])[0].get("tables", []):
-                    name = source.get('identifier', source["name"])
-                    print("SOURCE", name)
-                    if (not includes or name in includes) and (name not in excludes):
-                        mb_models.append(self.read_model(source))
+                for source in schema.get("sources", []):
+                    for model in source.get("tables", []):
+                        name = model.get("identifier", model["name"])
+                        print("SOURCE", name)
+                        if (not includes or name in includes) and (name not in excludes):
+                            mb_models.append(self.read_model(model))
 
         return mb_models
 

--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -36,21 +36,29 @@ class DbtReader:
         mb_models = []
 
         for path in (Path(self.project_path) / "models").rglob("*.yml"):
-            logging.info(path)
             with open(path, "r") as stream:
                 schema = yaml.safe_load(stream)
                 if schema is None:
-                    logging.warn(f"SKIPPING EMPTY/INVALID YML: {path}")
+                    logging.warn(
+                        "Skipping empty/invalid YML file at %s", 
+                        path
+                    )
                     continue
                 for model in schema.get("models", []):
                     name = model.get("identifier", model["name"])
-                    print("MODEL", name)
+                    logging.info(
+                        "Model: %s", 
+                        name
+                    )
                     if (not includes or name in includes) and (name not in excludes):
                         mb_models.append(self.read_model(model))
                 for source in schema.get("sources", []):
                     for model in source.get("tables", []):
                         name = model.get("identifier", model["name"])
-                        print("SOURCE", name)
+                        logging.info(
+                            "Source: %s", 
+                            name
+                        )
                         if (not includes or name in includes) and (name not in excludes):
                             mb_models.append(self.read_model(model))
 

--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -40,6 +40,7 @@ class DbtReader:
             with open(path, "r") as stream:
                 schema = yaml.safe_load(stream)
                 if schema is None:
+                    logging.warn(f"SKIPPING EMPTY/INVALID YML: {path}")
                     continue
                 for model in schema.get("models", []):
                     name = model.get("identifier", model["name"])

--- a/dbtmetabase/dbt.py
+++ b/dbtmetabase/dbt.py
@@ -36,12 +36,21 @@ class DbtReader:
         mb_models = []
 
         for path in (Path(self.project_path) / "models").rglob("*.yml"):
+            print(path)
             with open(path, "r") as stream:
                 schema = yaml.safe_load(stream)
+                if schema is None:
+                    continue
                 for model in schema.get("models", []):
-                    name = model["name"]
+                    name = model.get('identifier', model["name"])
+                    print("MODEL", name)
                     if (not includes or name in includes) and (name not in excludes):
                         mb_models.append(self.read_model(model))
+                for source in schema.get("sources", [{}])[0].get("tables", []):
+                    name = source.get('identifier', source["name"])
+                    print("SOURCE", name)
+                    if (not includes or name in includes) and (name not in excludes):
+                        mb_models.append(self.read_model(source))
 
         return mb_models
 
@@ -61,7 +70,7 @@ class DbtReader:
             mb_columns.append(self.read_column(column))
 
         return {
-            "name": model["name"].upper(),
+            "name": model.get('identifier', model["name"]).upper(),
             "description": model.get("description"),
             "columns": mb_columns,
         }
@@ -86,8 +95,8 @@ class DbtReader:
                 if "relationships" in test:
                     relationships = test["relationships"]
                     mb_column["semantic_type"] = "type/FK"
-                    mb_column["fk_target_table"] = self.parse_ref(
-                        relationships["to"]
+                    mb_column["fk_target_table"] = column.get("meta", {}).get(
+                        "metabase.fk_ref", self.parse_ref(relationships["to"])
                     ).upper()
                     mb_column["fk_target_field"] = relationships["field"].upper()
 


### PR DESCRIPTION
Added alias support in model parsing. Also added searching for "sources" yml blocks pushing table/column documentation to metabase (defining sources is recommended by dbt best practices and often done in tandem with creating staging models). Allows using "metabase.fk_ref" in sources or models .yml in order explicitly define a metabase relationship to a table which allows us to propagate the FK relationship properly to Metabase regardless of aliasing. metabase.fk_ref is looked for first in meta before falling back to default parser.