### PR TITLE
Rename 'test' workflow and 'run' status check to 'validate'

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,9 +4,9 @@ on:
       - master
 
 jobs:
-  run:
+  validate:
     runs-on: ubuntu-latest
-    name: run
+    name: validate
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
No functional difference but makes more sense in branch protection rules.