### PR TITLE
Fix 400 Errors on empty-string descriptions

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -155,6 +155,10 @@ class MetabaseClient:
             logging.error("Table %s does not exist in Metabase", model_name)
             return
 
+        # Empty strings not accepted by Metabase
+        if model["description"] == '':
+            model["description"] = None
+
         table_id = api_table["id"]
         if api_table["description"] != model["description"]:
             # Update with new values
@@ -219,6 +223,10 @@ class MetabaseClient:
         # Nones are not accepted, default to normal
         if not column.get("visibility_type"):
             column["visibility_type"] = "normal"
+
+        # Empty strings not accepted by Metabase
+        if column.get("description") == '':
+            column["description"] = None
 
         if (
             api_field["description"] != column.get("description")

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -156,7 +156,7 @@ class MetabaseClient:
             return
 
         # Empty strings not accepted by Metabase
-        if model["description"] == '':
+        if model["description"] == "":
             model["description"] = None
 
         table_id = api_table["id"]
@@ -225,7 +225,7 @@ class MetabaseClient:
             column["visibility_type"] = "normal"
 
         # Empty strings not accepted by Metabase
-        if column.get("description") == '':
+        if column.get("description") == "":
             column["description"] = None
 
         if (

--- a/setup.py
+++ b/setup.py
@@ -8,43 +8,41 @@ if sys.version_info < (3, 6):
 
 from dbtmetabase import __version__
 
-with open('requirements.txt', 'r') as f:
+with open("requirements.txt", "r") as f:
     requires = [x.strip() for x in f if x.strip()]
 
-with open('test-requirements.txt', 'r') as f:
+with open("test-requirements.txt", "r") as f:
     test_requires = [x.strip() for x in f if x.strip()]
 
-with open('README.rst', 'r') as f:
+with open("README.rst", "r") as f:
     readme = f.read()
 
 setup(
-    name='dbt-metabase',
+    name="dbt-metabase",
     version=__version__,
     description="Model synchronization from dbt to Metabase.",
     long_description=readme,
-    long_description_content_type='text/x-rst',
+    long_description_content_type="text/x-rst",
     author="Mike Gouline",
     author_email="hello@gouline.net",
-    url='https://github.com/gouline/dbt-metabase',
-    license='MIT License',
-    packages=find_packages(exclude=['tests']),
-    test_suite='tests',
-    scripts=[
-        'dbtmetabase/bin/dbt-metabase'
-    ],
+    url="https://github.com/gouline/dbt-metabase",
+    license="MIT License",
+    packages=find_packages(exclude=["tests"]),
+    test_suite="tests",
+    scripts=["dbtmetabase/bin/dbt-metabase"],
     tests_require=test_requires,
     install_requires=requires,
-    extras_require={'test': test_requires},
+    extras_require={"test": test_requires},
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )


### PR DESCRIPTION
I ran into this issue after I started using [dbt-invoke](https://github.com/dashlane/dbt-invoke) which generates boilerplate YAML schema files. To make it easier to populate, it adds empty descriptions for all columns.

