### PR TITLE
Add Argument --mb_http

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -147,9 +147,9 @@ def main(args: List = None):
     )
     parser.add_argument(
         "--mb_http",
-        dest='mb_https',
-        action='store_false',
-        help="use this option to use HTTP from the command line"
+        dest="mb_https",
+        action="store_false",
+        help="use this option to use HTTP from the command line",
     )
     parser.add_argument(
         "--mb_verify",

--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -146,6 +146,12 @@ def main(args: List = None):
         help="use HTTPS to connect to Metabase instead of HTTP",
     )
     parser.add_argument(
+        "--mb_http",
+        dest='mb_https',
+        action='store_false',
+        help="use this option to use HTTP from the command line"
+    )
+    parser.add_argument(
         "--mb_verify",
         metavar="CERT",
         help="Path to certificate bundle used by Metabase client",


### PR DESCRIPTION
I've started testing dbt-metabase and I ran into an issue with running `dbt-metabase export` from the command line with the `--mb_https` option.

I am running Metabase locally in a [docker container](https://www.metabase.com/docs/latest/operations-guide/running-metabase-on-docker.html) and was getting an SSL error. I found while troubleshooting that I can set mb_https to False when calling the export function from a Python script, but not from the command line.

I did some research and came up with a solution that adds an argument. I've tested it locally and I'm able to run the export from the command line.  I've never made an open-source PR before 🙈 , so please feel free to give me feedback/suggestions! I realize that adding an argument may not be optimal.