### PR TITLE
Argument naming, ordering and logic consistency

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -1,61 +1,60 @@
 import logging
 import sys
 import os
+import argparse
 
 from .metabase import MetabaseClient
 from .parsers.dbt_folder import DbtFolderReader
 from .parsers.dbt_manifest import DbtManifestReader
 
-from typing import Mapping, Iterable, List, Union
+from typing import Iterable, List, Union
 
 __version__ = "0.8.0"
 
 
 def export(
-    mb_host: str,
-    mb_user: str,
-    mb_password: str,
-    database: str,
     dbt_database: str,
+    metabase_database: str,
+    metabase_host: str,
+    metabase_user: str,
+    metabase_password: str,
     dbt_manifest_path: str = "",
     dbt_path: str = "",
+    dbt_docs_url: str = None,
+    metabase_use_http: bool = False,
+    metabase_verify: Union[str, bool] = True,
+    metabase_sync_skip: bool = False,
+    metabase_sync_timeout: int = None,
     schema: str = "public",
-    schemas_excludes: Iterable = None,
-    mb_use_http: bool = False,
-    mb_verify: Union[str, bool] = True,
-    mb_sync_skip: bool = False,
-    mb_sync_timeout: int = None,
+    schema_excludes: Iterable = None,
     includes: Iterable = None,
     excludes: Iterable = None,
     include_tags: bool = True,
-    dbt_docs_url: str = None,
 ):
     """Exports models from dbt to Metabase.
 
-    Arguments:
-        mb_host {str} -- Metabase hostname.
-        mb_user {str} -- Metabase username.
-        mb_password {str} -- Metabase password.
-        database {str} -- Target Metabase database name. Database in Metabase is aliased.
-        dbt_database {str} -- Source database name.
-        dbt_manifest_path {str} -- Path to dbt project manifest.json [Primary]
-        dbt_path {str} -- Path to dbt project. [Alternative]
-
-    Keyword Arguments:
-        schema {str} -- Target schema name. (default: {"public"})
-        schemas_excludes -- Alternative to target schema, specify schema exclusions. Only works for manifest parsing. (default: {None})
-        mb_use_http {bool} -- Use HTTP to connect to Metabase instead of the default HTTPS. (default: {False})
-        mb_verify {str} -- Supply path to certificate or disable verification. (default: {None})
-        mb_sync_skip {bool} -- Skip synchronizing Metabase database before export. (default: {False})
-        mb_sync_timeout {int} -- Metabase synchronization timeout in seconds. (default: {30})
-        includes {list} -- Model names to limit processing to. (default: {None})
-        excludes {list} -- Model names to exclude. (default: {None})
-        include_tags {bool} -- Append the dbt tags to the end of the table description. (default: {True})
-        dbt_docs_url {str} -- URL to your dbt docs hosted catalog. A link will be appended to the model description. Only works for manifest parsing. (default: {None})
+    Args:
+        dbt_database (str): Source database name.
+        metabase_database (str): Target Metabase database name. Database in Metabase is aliased.
+        metabase_host (str): Metabase hostname.
+        metabase_user (str): Metabase username.
+        metabase_password (str): Metabase password.
+        dbt_manifest_path (str, optional): Path to dbt project manifest.json [Primary]. Defaults to "".
+        dbt_path (str, optional): Path to dbt project. [Alternative]. Defaults to "".
+        dbt_docs_url (str, optional): URL to your dbt docs hosted catalog, a link will be appended to the model description (only works for manifest parsing). Defaults to None.
+        metabase_use_http (bool, optional): Use HTTP to connect to Metabase instead of the default HTTPS. Defaults to False.
+        metabase_verify (Union[str, bool], optional): Supply path to certificate or disable verification. Defaults to True.
+        metabase_sync_skip (bool, optional): Skip synchronizing Metabase database before export. Defaults to False.
+        metabase_sync_timeout (int, optional): Metabase synchronization timeout in seconds. Defaults to None.
+        schema (str, optional): Target schema name. Defaults to "public".
+        schema_excludes (Iterable, optional): Alternative to target schema, specify schema exclusions (only works for manifest parsing). Defaults to None.
+        includes (Iterable, optional): Model names to limit processing to. Defaults to None.
+        excludes (Iterable, optional): Model names to exclude. Defaults to None.
+        include_tags (bool, optional): Append the dbt tags to the end of the table description. Defaults to True.
     """
 
-    if schemas_excludes is None:
-        schemas_excludes = []
+    if schema_excludes is None:
+        schema_excludes = []
     if includes is None:
         includes = []
     if excludes is None:
@@ -67,14 +66,20 @@ def export(
     ), "Bad arguments. dbt_path and dbt_manifest_path cannot be provide at the same time. One option must be specified."
     if dbt_path:
         assert (
-            schema and not schemas_excludes
+            schema and not schema_excludes
         ), "Must target a single schema if using yaml parser, multiple schemas not supported."
     assert bool(schema) != bool(
-        schemas_excludes
+        schema_excludes
     ), "Bad arguments. schema and schema_excludes cannot be provide at the same time. One option must be specified."
 
     # Instantiate Metabase client
-    mbc = MetabaseClient(mb_host, mb_user, mb_password, mb_use_http, verify=mb_verify)
+    mbc = MetabaseClient(
+        host=metabase_host,
+        user=metabase_user,
+        password=metabase_password,
+        use_http=metabase_use_http,
+        verify=metabase_verify,
+    )
     reader: Union[DbtFolderReader, DbtManifestReader]
 
     # Resolve dbt reader being either YAML or manifest.json based
@@ -83,35 +88,33 @@ def export(
     else:
         reader = DbtManifestReader(os.path.expandvars(dbt_manifest_path))
 
-    if schemas_excludes:
-        schemas_excludes = {schema.upper() for schema in schemas_excludes}
+    if schema_excludes:
+        schema_excludes = {schema.upper() for schema in schema_excludes}
 
     # Process dbt stuff
     models = reader.read_models(
         database=dbt_database,
         schema=schema,
-        schemas_excludes=schemas_excludes,
+        schema_excludes=schema_excludes,
         includes=includes,
         excludes=excludes,
         include_tags=include_tags,
-        dbt_docs_url=dbt_docs_url,
+        docs_url=dbt_docs_url,
     )
 
     # Sync and attempt schema alignment prior to execution; if timeout is not explicitly set, proceed regardless of success
-    if not mb_sync_skip:
-        if mb_sync_timeout is not None and not mbc.sync_and_wait(
-            database, schema, models, mb_sync_timeout
+    if not metabase_sync_skip:
+        if metabase_sync_timeout is not None and not mbc.sync_and_wait(
+            metabase_database, schema, models, metabase_sync_timeout
         ):
             logging.critical("Sync timeout reached, models still not compatible")
             return
 
     # Process Metabase stuff
-    mbc.export_models(database, schema, models, reader.catch_aliases)
+    mbc.export_models(metabase_database, schema, models, reader.catch_aliases)
 
 
 def main(args: List = None):
-    import argparse
-
     logging.basicConfig(
         format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO
     )
@@ -120,46 +123,67 @@ def main(args: List = None):
         description="Model synchronization from dbt to Metabase."
     )
     parser.add_argument("command", choices=["export"], help="command to execute")
-    parser.add_argument(
-        "--dbt_path",
-        help="Path to dbt project. Cannot be specified with --dbt_manifest_path",
-    )
-    parser.add_argument(
-        "--dbt_manifest_path",
-        help="Path to dbt manifest.json typically located in the /target/ directory of the dbt project directory. Cannot be specified with --dbt_path",
-    )
-    parser.add_argument(
-        "--mb_host", metavar="HOST", required=True, help="Metabase hostname"
-    )
-    parser.add_argument(
-        "--mb_user", metavar="USER", required=True, help="Metabase username"
-    )
-    parser.add_argument(
-        "--mb_password", metavar="PASS", required=True, help="Metabase password"
-    )
-    parser.add_argument(
-        "--mb_http",
-        dest="mb_http",
-        action="store_true",
-        help="use HTTP to connect to Metabase instead of HTTPS",
-    )
-    parser.add_argument(
-        "--mb_verify",
-        metavar="CERT",
-        help="Path to certificate bundle used by Metabase client",
-    )
-    parser.add_argument(
-        "--database",
-        metavar="ALIAS",
-        required=True,
-        help="Target database name as set in Metabase (typically aliased)",
-    )
+
+    # dbt arguments
     parser.add_argument(
         "--dbt_database",
         metavar="DB",
         required=True,
         help="Target database name as specified in dbt",
     )
+    parser.add_argument(
+        "--dbt_path",
+        help="Path to dbt project. Cannot be specified with --dbt_manifest_path",
+    )
+    parser.add_argument(
+        "--dbt_manifest_path",
+        help="Path to dbt manifest.json (typically located in the /target/ directory of the dbt project directory). Cannot be specified with --dbt_path",
+    )
+    parser.add_argument(
+        "--dbt_docs",
+        metavar="URL",
+        help="Pass in URL to dbt docs site. Appends dbt docs URL for each model to Metabase table description",
+    )
+
+    # Metabase arguments
+    parser.add_argument(
+        "--metabase_database",
+        metavar="DB",
+        required=True,
+        help="Target database name as set in Metabase (typically aliased)",
+    )
+    parser.add_argument(
+        "--metabase_host", metavar="HOST", required=True, help="Metabase hostname"
+    )
+    parser.add_argument(
+        "--metabase_user", metavar="USER", required=True, help="Metabase username"
+    )
+    parser.add_argument(
+        "--metabase_password", metavar="PASS", required=True, help="Metabase password"
+    )
+    parser.add_argument(
+        "--metabase_use_http",
+        action="store_true",
+        help="use HTTP to connect to Metabase instead of HTTPS",
+    )
+    parser.add_argument(
+        "--metabase_verify",
+        metavar="CERT",
+        help="Path to certificate bundle used by Metabase client",
+    )
+    parser.add_argument(
+        "--metabase_sync_skip",
+        action="store_true",
+        help="Skip synchronizing Metabase database before export",
+    )
+    parser.add_argument(
+        "--metabase_sync_timeout",
+        metavar="SECS",
+        type=int,
+        help="Synchronization timeout (in secs). If set, we will fail hard on synchronization failure; if not set, we will proceed after attempting sync regardless of success",
+    )
+
+    # Common/misc arguments
     parser.add_argument(
         "--schema",
         metavar="SCHEMA",
@@ -168,18 +192,6 @@ def main(args: List = None):
     parser.add_argument(
         "--schema_excludes",
         help="Target schemas to exclude. Cannot be specified with --schema. Will sync all schemas not excluded",
-    )
-    parser.add_argument(
-        "--mb_sync_skip",
-        dest="mb_sync_skip",
-        action="store_true",
-        help="Skip synchronizing Metabase database before export",
-    )
-    parser.add_argument(
-        "--mb_sync_timeout",
-        metavar="SECS",
-        type=int,
-        help="Synchronization timeout (in secs). If set, we will fail hard on synchronization failure; if not set, we will proceed after attempting sync regardless of success",
     )
     parser.add_argument(
         "--includes",
@@ -202,16 +214,12 @@ def main(args: List = None):
         help="Append tags to Table descriptions in Metabase",
     )
     parser.add_argument(
-        "--docs",
-        metavar="DOCS URL",
-        help="Pass in url to dbt docs site. Appends dbt docs url for each model to Metabase table description",
-    )
-    parser.add_argument(
         "--verbose",
         action="store_true",
         default=False,
         help="Verbose output",
     )
+
     parsed = parser.parse_args(args=args)
 
     if parsed.verbose:
@@ -221,21 +229,21 @@ def main(args: List = None):
 
     if parsed.command == "export":
         export(
-            dbt_path=parsed.dbt_path,
-            dbt_manifest_path=parsed.dbt_manifest_path,
             dbt_database=parsed.dbt_database,
-            mb_host=parsed.mb_host,
-            mb_user=parsed.mb_user,
-            mb_password=parsed.mb_password,
-            mb_use_http=parsed.mb_use_http,
-            mb_verify=parsed.mb_verify,
-            database=parsed.database,
+            dbt_manifest_path=parsed.dbt_manifest_path,
+            dbt_path=parsed.dbt_path,
+            dbt_docs_url=parsed.dbt_docs,
+            metabase_database=parsed.metabase_database,
+            metabase_host=parsed.metabase_host,
+            metabase_user=parsed.metabase_user,
+            metabase_password=parsed.metabase_password,
+            metabase_use_http=parsed.metabase_use_http,
+            metabase_verify=parsed.metabase_verify,
+            metabase_sync_skip=parsed.metabase_sync_skip,
+            metabase_sync_timeout=parsed.metabase_sync_timeout,
             schema=parsed.schema,
-            schemas_excludes=parsed.schema_excludes,
-            mb_sync_skip=parsed.mb_sync_skip,
-            mb_sync_timeout=parsed.mb_sync_timeout,
+            schema_excludes=parsed.schema_excludes,
             includes=parsed.includes,
             excludes=parsed.excludes,
             include_tags=parsed.include_tags,
-            dbt_docs_url=parsed.docs,
         )

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -18,7 +18,7 @@ class MetabaseClient:
         host: str,
         user: str,
         password: str,
-        https: bool = True,
+        use_http: bool = False,
         verify: Union[str, bool] = None,
     ):
         """Constructor.
@@ -29,11 +29,12 @@ class MetabaseClient:
             password {str} -- Metabase password.
 
         Keyword Arguments:
-            https {bool} -- Use HTTPS instead of HTTP. (default: {True})
+            use_http {bool} -- Use HTTP instead of HTTPS. (default: {False})
+            verify {Union[str, bool]} -- Path to certificate or disable verification. (default: {None})
         """
 
         self.host = host
-        self.protocol = "https" if https else "http"
+        self.protocol = "http" if use_http else "https"
         self.verify = verify
         self.session_id = self.get_session_id(user, password)
         logging.info("Session established successfully")

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -30,11 +30,11 @@ class DbtFolderReader:
         self,
         database: str,
         schema: str,
-        schemas_excludes: Iterable = None,
+        schema_excludes: Iterable = None,
         includes: Iterable = None,
         excludes: Iterable = None,
         include_tags: bool = True,
-        dbt_docs_url: str = None,
+        docs_url: str = None,
     ) -> List[MetabaseModel]:
         """Reads dbt models in Metabase-friendly format.
 
@@ -46,8 +46,8 @@ class DbtFolderReader:
             list -- List of dbt models in Metabase-friendly format.
         """
 
-        if schemas_excludes is None:
-            schemas_excludes = []
+        if schema_excludes is None:
+            schema_excludes = []
         if includes is None:
             includes = []
         if excludes is None:
@@ -59,10 +59,10 @@ class DbtFolderReader:
                 database,
             )
 
-        if dbt_docs_url:
+        if docs_url:
             logging.info(
-                "Argument --dbt_docs_url %s is unused in dbt_project yml parser. Use manifest parser instead.",
-                dbt_docs_url,
+                "Argument --docs_url %s is unused in dbt_project yml parser. Use manifest parser instead.",
+                docs_url,
             )
 
         mb_models: List[MetabaseModel] = []
@@ -189,11 +189,7 @@ class DbtFolderReader:
                     mb_column.fk_target_table = mb_column.fk_target_table.upper()
                     # Account for (example) '"Id"' relationship: to: fields used as a workaround for current tests not quoting consistently
                     mb_column.fk_target_field = (
-                        relationships["field"]
-                        .upper()
-                        .strip(
-                            '"'
-                        )
+                        relationships["field"].upper().strip('"')
                     )
 
         if "meta" in column:

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -27,15 +27,15 @@ class DbtManifestReader:
         self,
         database: str,
         schema: str,
-        schemas_excludes: Iterable = None,
+        schema_excludes: Iterable = None,
         includes: Iterable = None,
         excludes: Iterable = None,
         include_tags: bool = True,
-        dbt_docs_url: str = None,
+        docs_url: str = None,
     ) -> List[MetabaseModel]:
 
-        if schemas_excludes is None:
-            schemas_excludes = []
+        if schema_excludes is None:
+            schema_excludes = []
         if includes is None:
             includes = []
         if excludes is None:
@@ -78,7 +78,7 @@ class DbtManifestReader:
                 )
                 continue
 
-            if schemas_excludes and node["schema"].upper() in schemas_excludes:
+            if schema_excludes and node["schema"].upper() in schema_excludes:
                 # Skip any model in a schema marked for exclusion
                 logging.debug(
                     "Skipping %s in schema %s marked for exclusion",
@@ -96,9 +96,7 @@ class DbtManifestReader:
                 continue
 
             mb_models.append(
-                self._read_model(
-                    node, include_tags=include_tags, dbt_docs_url=dbt_docs_url
-                )
+                self._read_model(node, include_tags=include_tags, docs_url=docs_url)
             )
 
         for _, node in self.manifest["sources"].items():
@@ -126,7 +124,7 @@ class DbtManifestReader:
                 )
                 continue
 
-            if schemas_excludes and node["schema"].upper() in schemas_excludes:
+            if schema_excludes and node["schema"].upper() in schema_excludes:
                 # Skip any model in a schema marked for exclusion
                 logging.debug(
                     "Skipping %s in schema %s marked for exclusion",
@@ -147,7 +145,7 @@ class DbtManifestReader:
                 self._read_model(
                     node,
                     include_tags=include_tags,
-                    dbt_docs_url=dbt_docs_url,
+                    docs_url=docs_url,
                     manifest_key="sources",
                 )
             )
@@ -158,7 +156,7 @@ class DbtManifestReader:
         self,
         model: dict,
         include_tags: bool = True,
-        dbt_docs_url: str = None,
+        docs_url: str = None,
         manifest_key: str = "nodes",
     ) -> MetabaseModel:
         """Reads one dbt model in Metabase-friendly format.
@@ -221,8 +219,8 @@ class DbtManifestReader:
                     description += "\n\n"
                 description += f"Tags: {tags}"
 
-        if dbt_docs_url:
-            full_path = f"{dbt_docs_url}/#!/model/{model['unique_id']}"
+        if docs_url:
+            full_path = f"{docs_url}/#!/model/{model['unique_id']}"
             if description != "":
                 description += "\n\n"
             description += f"dbt docs link: {full_path}"

--- a/tests/test_metabase.py
+++ b/tests/test_metabase.py
@@ -14,7 +14,7 @@ class TestMetabaseClient(unittest.TestCase):
             host="localhost",
             user="dummy",
             password="dummy",
-            https=False,
+            use_http=True,
         )
 
     def test_dummy(self):


### PR DESCRIPTION
Big refactor of CLI/programmatic entry point arguments, to achieve some readability and consistency.

- Arguments only belonging to dbt or Metabase are clearly prefixed with `dbt_` or `metabase_` respectively (common arguments are not prefixed)
- Prefix `mb_` becomes `metabase_` for clarity
- Optional boolean arguments should be false by default, e.g. if we mandate HTTPS to be the default (as we should because it's 2021), optional override should be `use_http`, instead of `use_https` that's true by default overridable to false
- Starting to use the new default format for header comments in VS Code, not going to replace all existing ones (too lazy, maybe in the future), but any new ones or significantly reworked ones are easier to re-create than edit, e.g. see `export()`

We're making a lot of breaking changes with the next release that will feature manifest parsing, we may as well break anything else we need in the process to go along with it.

(Addresses #30 among other things)