### PR TITLE
Fix for new pagination envelope in Metabase 0.40.0

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -470,4 +470,10 @@ class MetabaseClient:
                 raise
         elif not response.ok:
             return False
-        return json.loads(response.text)
+
+        response_json = json.loads(response.text)
+
+        # Since X.40.0 responses are encapsulated in "data" with pagination parameters
+        if "data" in response_json:
+            return response_json["data"]
+        return response_json


### PR DESCRIPTION
Since Metabase 0.40.0, API responses are encapsulated in:

```
{
    "data": [ "OLD RESPONSE HERE" ],
    "limit": 50,
    "offset": 0,
    "total": 2
}
```

This change checks if "data" key is present in the root and uses that instead. I will revisit this later, if I need to cater for pagination issues in requests.