### PR TITLE
Make GitHub Actions naming consistent

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,37 @@
+name: master
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Requirements
+        run: make requirements
+
+      - name: Build
+        run: make build
+
+      - name: Lint check
+        run: make lint
+
+      - name: Type check
+        run: make type
+
+      - name: Test
+        run: make test
+
+      - name: Publish a Python distribution to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,15 +1,12 @@
-name: Main
+name: pull_request
 
 on:
   pull_request:
     branches:
       - master
-  release:
-    types: [created]
 
 jobs:
-  build:
-    name: Build and validate
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -35,10 +32,3 @@ jobs:
 
       - name: Test
         run: make test
-
-      - name: Publish a Python distribution to PyPI
-        if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 dbt-metabase
 ############
 
-.. image:: https://github.com/gouline/dbt-metabase/actions/workflows/main.yml/badge.svg
-    :target: https://github.com/gouline/dbt-metabase/actions/workflows/main.yml
+.. image:: https://github.com/gouline/dbt-metabase/actions/workflows/master.yml/badge.svg
+    :target: https://github.com/gouline/dbt-metabase/actions/workflows/master.yml
     :alt: GitHub Actions
 .. image:: https://img.shields.io/pypi/v/dbt-metabase
     :target: https://pypi.org/project/dbt-metabase/
@@ -11,7 +11,7 @@ dbt-metabase
     :target: https://pepy.tech/project/dbt-metabase
     :alt: Downloads
 .. image:: https://black.readthedocs.io/en/stable/_static/license.svg
-    :target: https://github.com/gouline/dbt-metabase/blob/main/LICENSE
+    :target: https://github.com/gouline/dbt-metabase/blob/master/LICENSE
     :alt: License: MIT
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black


### PR DESCRIPTION
Separate pull request build (that could be failing often) from the master branch one that does releases and is displayed in the badge at the top of README.