### PR TITLE
Add formatter to CI checks

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,11 +20,14 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Lint check
-        run: make lint
+      - name: Formatting check (black)
+        run: make check-fmt
 
-      - name: Type check
-        run: make type
+      - name: Lint check (pylint)
+        run: make check-lint
+
+      - name: Type check (mypy)
+        run: make check-type
 
       - name: Test
         run: make test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,11 +24,14 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Lint check
-        run: make lint
+      - name: Formatting check (black)
+        run: make check-fmt
 
-      - name: Type check
-        run: make type
+      - name: Lint check (pylint)
+        run: make check-lint
+
+      - name: Type check (mypy)
+        run: make check-type
 
       - name: Test
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -9,25 +9,32 @@ requirements:
 	pip3 install -r requirements-test.txt
 .PHONY: requirements
 
-lint:
-	pylint dbtmetabase
-.PHONY: lint
+fmt:
+	black .
 
-type:
+check-fmt:
+	black --check .
+.PHONY: check-fmt
+
+check-lint:
+	pylint dbtmetabase
+.PHONY: check-lint
+
+check-type:
 	mypy dbtmetabase
-.PHONY: type
+.PHONY: check-type
 
 test:
 	python3 -m unittest tests
 .PHONY: test
 
-check: build
+dist-check: build
 	twine check dist/*
-.PHONY: check
+.PHONY: dist-check
 
-upload: check
+dist-upload: check
 	twine upload dist/*
-.PHONY: upload
+.PHONY: dist-upload
 
 dev-install: build
 	pip3 uninstall -y dbt-metabase && pip3 install dist/dbt_metabase-*-py3-none-any.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 write_to = "dbtmetabase/_version.py"
 
 [tool.black]
-line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39']
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 
 [tool.mypy]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pylint
 mypy
 types-requests
 types-PyYAML
+black

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,11 @@ from setuptools import setup, find_packages
 if sys.version_info < (3, 6):
     raise ValueError("Requires Python 3.6+")
 
+
 def requires_from_file(filename: str) -> list:
     with open(filename, "r") as f:
         return [x.strip() for x in f if x.strip()]
+
 
 with open("README.rst", "r") as f:
     readme = f.read()
@@ -28,7 +30,7 @@ setup(
     test_suite="tests",
     install_requires=requires_from_file("requirements.txt"),
     extras_require={
-        "test":requires_from_file("requirements-test.txt")
+        "test": requires_from_file("requirements-test.txt"),
     },
     setup_requires=["setuptools_scm"],
     classifiers=[


### PR DESCRIPTION
Automatically check formatting with https://github.com/psf/black in CI (using `make check-fmt`) and allow formatting from CLI using `make fmt` (although IDE integration is easier).