### PR TITLE
Optional version import

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -6,10 +6,11 @@ import argparse
 from .metabase import MetabaseClient
 from .parsers.dbt_folder import DbtFolderReader
 from .parsers.dbt_manifest import DbtManifestReader
+from .utils import get_version
 
 from typing import Iterable, List, Union
 
-from ._version import version as __version__
+__version__ = get_version()
 
 
 def export(
@@ -121,6 +122,11 @@ def main(args: List = None):
 
     parser = argparse.ArgumentParser(
         description="Model synchronization from dbt to Metabase."
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parser.add_argument("command", choices=["export"], help="command to execute")
 

--- a/dbtmetabase/utils.py
+++ b/dbtmetabase/utils.py
@@ -1,0 +1,24 @@
+import logging
+import importlib.metadata
+
+
+def get_version() -> str:
+    """Checks _version.py or build metadata for package version.
+
+    Returns:
+        str: Version string.
+    """
+
+    try:
+        from ._version import version
+
+        return version
+    except ModuleNotFoundError:
+        logging.debug("No _version.py found")
+
+    try:
+        return importlib.metadata.version("dbt-metabase")
+    except importlib.metadata.PackageNotFoundError:
+        logging.warning("No version found in metadata")
+
+    return "0.0.0-UNKONWN"


### PR DESCRIPTION
Fixes missing `_version.py` when installing using pip from git branch, instead of PyPI https://github.com/gouline/dbt-metabase/pull/38#discussion_r675640224

When running from PyPI version and the `_version.py` is generated, it will use that, otherwise it will read from metadata, which seems to be populated correctly in the above installation method.

Also adding `--version` to quickly check your version, like most command-line tools.