### PR TITLE
Restore Python 3.6+ compatibility

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6.x'
+
       - name: Requirements
         run: make requirements
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           python-version: '3.6.x'
 
-      - name: Build requirements
-        run: pip3 install "setuptools>=45" wheel
-
       - name: Requirements
         run: make requirements
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           python-version: '3.6.x'
 
+      - name: Build requirements
+        run: pip3 install "setuptools>=45" wheel
+
       - name: Requirements
         run: make requirements
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6.x'
+
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Build requirements
+        run: pip3 install "setuptools>=45" wheel
+
       - name: Requirements
         run: make requirements
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,9 +22,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Build requirements
-        run: pip3 install "setuptools>=45" wheel
-
       - name: Requirements
         run: make requirements
 

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -1,9 +1,16 @@
 from dataclasses import dataclass, field
-from typing import Sequence, Optional, MutableMapping, Literal
+from enum import Enum
+
+from typing import Sequence, Optional, MutableMapping
 
 # Allowed metabase.* fields
 # Should be covered by attributes in the MetabaseColumn class
 METABASE_META_FIELDS = ["special_type", "semantic_type", "visibility_type"]
+
+
+class ModelKey(str, Enum):
+    nodes = "nodes"
+    sources = "sources"
 
 
 @dataclass
@@ -25,7 +32,7 @@ class MetabaseModel:
     name: str
     schema: str
     description: str = ""
-    model_key: Literal["nodes", "sources"] = "nodes"
+    model_key: ModelKey = ModelKey.nodes
     ref: Optional[str] = None
 
     columns: Sequence[MetabaseColumn] = field(default_factory=list)

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -1,9 +1,9 @@
 import json
-import os
-from typing import List, Iterable, Mapping, Optional, MutableMapping, Literal
 import logging
+import os
+from typing import List, Iterable, Mapping, Optional, MutableMapping
 
-from ..models.metabase import METABASE_META_FIELDS
+from ..models.metabase import METABASE_META_FIELDS, ModelKey
 from ..models.metabase import MetabaseModel, MetabaseColumn
 
 
@@ -146,7 +146,7 @@ class DbtManifestReader:
                     node,
                     include_tags=include_tags,
                     docs_url=docs_url,
-                    model_key="sources",
+                    model_key=ModelKey.sources,
                     source=node["source_name"],
                 )
             )
@@ -158,7 +158,7 @@ class DbtManifestReader:
         model: dict,
         include_tags: bool = True,
         docs_url: Optional[str] = None,
-        model_key: Literal["nodes", "sources"] = "nodes",
+        model_key: ModelKey = ModelKey.nodes,
         source: Optional[str] = None,
     ) -> MetabaseModel:
         """Reads one dbt model in Metabase-friendly format.
@@ -225,12 +225,12 @@ class DbtManifestReader:
                 description += "\n\n"
             description += f"dbt docs link: {full_path}"
 
-        if model_key == "nodes":
+        ref: Optional[str] = None
+
+        if model_key == ModelKey.nodes:
             ref = f"ref('{model.get('identifier', model['name'])}')"
-        elif model_key == "sources":
+        elif model_key == ModelKey.sources:
             ref = f"source('{source}', '{model['name']}')"
-        else:
-            ref = None
 
         return MetabaseModel(
             name=model.get("alias", model.get("identifier", model.get("name"))).upper(),

--- a/dbtmetabase/utils.py
+++ b/dbtmetabase/utils.py
@@ -1,5 +1,4 @@
 import logging
-import importlib.metadata
 
 
 def get_version() -> str:
@@ -16,9 +15,17 @@ def get_version() -> str:
     except ModuleNotFoundError:
         logging.debug("No _version.py found")
 
+    # importlib is only available on Python 3.6+
     try:
-        return importlib.metadata.version("dbt-metabase")
-    except importlib.metadata.PackageNotFoundError:
-        logging.warning("No version found in metadata")
+        import importlib.metadata
+
+        try:
+            return importlib.metadata.version("dbt-metabase")
+        except importlib.metadata.PackageNotFoundError:
+            logging.warning("No version found in metadata")
+    except ModuleNotFoundError:
+        logging.warning(
+            "metadata package not available to retrieve the package version"
+        )
 
     return "0.0.0-UNKONWN"

--- a/dbtmetabase/utils.py
+++ b/dbtmetabase/utils.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 
 def get_version() -> str:
@@ -15,19 +16,14 @@ def get_version() -> str:
     except ModuleNotFoundError:
         logging.debug("No _version.py found")
 
-    # importlib is only available on Python 3.6+
-    # pylint also needs to be ignored
-    try:
-        # pylint: disable=import-error,no-name-in-module,no-member
+    # importlib is only available on Python 3.8+
+    if sys.version_info >= (3, 8):
+        # pylint: disable=no-member
         import importlib.metadata
 
         try:
             return importlib.metadata.version("dbt-metabase")
         except importlib.metadata.PackageNotFoundError:
             logging.warning("No version found in metadata")
-    except ModuleNotFoundError:
-        logging.warning(
-            "metadata package not available to retrieve the package version"
-        )
 
     return "0.0.0-UNKONWN"

--- a/dbtmetabase/utils.py
+++ b/dbtmetabase/utils.py
@@ -16,7 +16,9 @@ def get_version() -> str:
         logging.debug("No _version.py found")
 
     # importlib is only available on Python 3.6+
+    # pylint also needs to be ignored
     try:
+        # pylint: disable=import-error,no-name-in-module,no-member
         import importlib.metadata
 
         try:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 setuptools>=45
-wheels
+wheel
 pylint
 mypy
 types-requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
+setuptools>=45
+wheels
 pylint
 mypy
 types-requests

--- a/tests/test_dbt_folder_reader.py
+++ b/tests/test_dbt_folder_reader.py
@@ -1,11 +1,12 @@
+import logging
 import unittest
 
+from dbtmetabase.models.metabase import ModelKey
 from dbtmetabase.parsers.dbt_folder import (
     DbtFolderReader,
     MetabaseModel,
     MetabaseColumn,
 )
-import logging
 
 
 class MockDbtFolderReader(DbtFolderReader):
@@ -29,7 +30,7 @@ class TestDbtFolderReader(unittest.TestCase):
                 name="CUSTOMERS",
                 schema="PUBLIC",
                 description="This table has basic information about a customer, as well as some derived facts based on a customer's orders",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('customers')",
                 columns=[
                     MetabaseColumn(
@@ -101,7 +102,7 @@ class TestDbtFolderReader(unittest.TestCase):
                 name="ORDERS",
                 schema="PUBLIC",
                 description="This table has basic information about orders, as well as some derived facts based on payments",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('orders')",
                 columns=[
                     MetabaseColumn(
@@ -191,7 +192,7 @@ class TestDbtFolderReader(unittest.TestCase):
                 name="STG_CUSTOMERS",
                 schema="PUBLIC",
                 description="",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('stg_customers')",
                 columns=[
                     MetabaseColumn(
@@ -209,7 +210,7 @@ class TestDbtFolderReader(unittest.TestCase):
                 name="STG_ORDERS",
                 schema="PUBLIC",
                 description="",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('stg_orders')",
                 columns=[
                     MetabaseColumn(
@@ -236,7 +237,7 @@ class TestDbtFolderReader(unittest.TestCase):
                 name="STG_PAYMENTS",
                 schema="PUBLIC",
                 description="",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('stg_payments')",
                 columns=[
                     MetabaseColumn(

--- a/tests/test_dbt_manifest_reader.py
+++ b/tests/test_dbt_manifest_reader.py
@@ -1,11 +1,12 @@
+import logging
 import unittest
 
+from dbtmetabase.models.metabase import ModelKey
 from dbtmetabase.parsers.dbt_manifest import (
     DbtManifestReader,
     MetabaseModel,
     MetabaseColumn,
 )
-import logging
 
 
 class MockDbtManifestReader(DbtManifestReader):
@@ -30,7 +31,7 @@ class TestDbtManifestReader(unittest.TestCase):
                 name="ORDERS",
                 schema="PUBLIC",
                 description="This table has basic information about orders, as well as some derived facts based on payments",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('orders')",
                 columns=[
                     MetabaseColumn(
@@ -120,7 +121,7 @@ class TestDbtManifestReader(unittest.TestCase):
                 name="CUSTOMERS",
                 schema="PUBLIC",
                 description="This table has basic information about a customer, as well as some derived facts based on a customer's orders",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('customers')",
                 columns=[
                     MetabaseColumn(
@@ -192,7 +193,7 @@ class TestDbtManifestReader(unittest.TestCase):
                 name="STG_ORDERS",
                 schema="PUBLIC",
                 description="",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('stg_orders')",
                 columns=[
                     MetabaseColumn(
@@ -219,7 +220,7 @@ class TestDbtManifestReader(unittest.TestCase):
                 name="STG_PAYMENTS",
                 schema="PUBLIC",
                 description="",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('stg_payments')",
                 columns=[
                     MetabaseColumn(
@@ -246,7 +247,7 @@ class TestDbtManifestReader(unittest.TestCase):
                 name="STG_CUSTOMERS",
                 schema="PUBLIC",
                 description="",
-                model_key="nodes",
+                model_key=ModelKey.nodes,
                 ref="ref('stg_customers')",
                 columns=[
                     MetabaseColumn(

--- a/tests/test_metabase.py
+++ b/tests/test_metabase.py
@@ -1,23 +1,22 @@
+import json
+import logging
+import os
 import unittest
+import yaml
 
 from dbtmetabase.metabase import MetabaseClient
 from dbtmetabase.models.metabase import (
     MetabaseModel,
     MetabaseColumn,
+    ModelKey,
 )
-
-import logging
-import json
-import yaml
-import os
-
 
 MODELS = [
     MetabaseModel(
         name="ORDERS",
         schema="PUBLIC",
         description="This table has basic information about orders, as well as some derived facts based on payments",
-        model_key="nodes",
+        model_key=ModelKey.nodes,
         ref="ref('orders')",
         columns=[
             MetabaseColumn(
@@ -107,7 +106,7 @@ MODELS = [
         name="CUSTOMERS",
         schema="PUBLIC",
         description="This table has basic information about a customer, as well as some derived facts based on a customer's orders",
-        model_key="nodes",
+        model_key=ModelKey.nodes,
         ref="ref('customers')",
         columns=[
             MetabaseColumn(
@@ -179,7 +178,7 @@ MODELS = [
         name="STG_ORDERS",
         schema="PUBLIC",
         description="",
-        model_key="nodes",
+        model_key=ModelKey.nodes,
         ref="ref('stg_orders')",
         columns=[
             MetabaseColumn(
@@ -206,7 +205,7 @@ MODELS = [
         name="STG_PAYMENTS",
         schema="PUBLIC",
         description="",
-        model_key="nodes",
+        model_key=ModelKey.nodes,
         ref="ref('stg_payments')",
         columns=[
             MetabaseColumn(
@@ -233,7 +232,7 @@ MODELS = [
         name="STG_CUSTOMERS",
         schema="PUBLIC",
         description="",
-        model_key="nodes",
+        model_key=ModelKey.nodes,
         ref="ref('stg_customers')",
         columns=[
             MetabaseColumn(

--- a/tests/utils_mb_test_suite.py
+++ b/tests/utils_mb_test_suite.py
@@ -1,12 +1,13 @@
+import json
+import logging
+import os
+
 from dbtmetabase.metabase import MetabaseClient
 from dbtmetabase.models.metabase import (
     MetabaseModel,
     MetabaseColumn,
+    ModelKey,
 )
-
-import json
-import logging
-import os
 
 mbc = MetabaseClient(
     host="localhost:3000",
@@ -108,7 +109,7 @@ def rebuild_baseline_exposure_yaml():
             name="CUSTOMERS",
             schema="PUBLIC",
             description="This table has basic information about a customer, as well as some derived facts based on a customer's orders",
-            model_key="nodes",
+            model_key=ModelKey.nodes,
             ref="ref('customers')",
             columns=[
                 MetabaseColumn(
@@ -180,7 +181,7 @@ def rebuild_baseline_exposure_yaml():
             name="ORDERS",
             schema="PUBLIC",
             description="This table has basic information about orders, as well as some derived facts based on payments",
-            model_key="nodes",
+            model_key=ModelKey.nodes,
             ref="ref('orders')",
             columns=[
                 MetabaseColumn(
@@ -270,7 +271,7 @@ def rebuild_baseline_exposure_yaml():
             name="STG_CUSTOMERS",
             schema="PUBLIC",
             description="",
-            model_key="nodes",
+            model_key=ModelKey.nodes,
             ref="ref('stg_customers')",
             columns=[
                 MetabaseColumn(
@@ -288,7 +289,7 @@ def rebuild_baseline_exposure_yaml():
             name="STG_ORDERS",
             schema="PUBLIC",
             description="",
-            model_key="nodes",
+            model_key=ModelKey.nodes,
             ref="ref('stg_orders')",
             columns=[
                 MetabaseColumn(
@@ -315,7 +316,7 @@ def rebuild_baseline_exposure_yaml():
             name="STG_PAYMENTS",
             schema="PUBLIC",
             description="",
-            model_key="nodes",
+            model_key=ModelKey.nodes,
             ref="ref('stg_payments')",
             columns=[
                 MetabaseColumn(


### PR DESCRIPTION
Resolves #52

- [x] Reverts using `Literal` so the project runs on Python 3.6+
- [x] Uses Python 3.6.x on the GitHub Actions to make sure the project runs on Python 3.6+