### PR TITLE
Set explicit utf-8 encoding when opening files

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -572,7 +572,9 @@ class MetabaseClient:
 
         # Output dbt YAML
         with open(
-            os.path.expanduser(os.path.join(output_path, f"{output_name}.yml")), "w"
+            os.path.expanduser(os.path.join(output_path, f"{output_name}.yml")),
+            "w",
+            encoding="utf-8",
         ) as docs:
             yaml.dump(
                 {"version": _RESOURCE_VERSION, "exposures": parsed_exposures},

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -62,7 +62,7 @@ class DbtFolderReader:
 
         for path in (Path(self.project_path) / "models").rglob("*.yml"):
             logging.info("Processing model: %s", path)
-            with open(path, "r") as stream:
+            with open(path, "r", encoding="utf-8") as stream:
                 schema_file = yaml.safe_load(stream)
                 if schema_file is None:
                     logging.warning("Skipping empty or invalid YAML: %s", path)

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -44,7 +44,7 @@ class DbtManifestReader:
         path = self.manifest_path
         mb_models: List[MetabaseModel] = []
 
-        with open(path, "r") as manifest_file:
+        with open(path, "r", encoding="utf-8") as manifest_file:
             self.manifest = json.load(manifest_file)
 
         for _, node in self.manifest["nodes"].items():


### PR DESCRIPTION
Addressing `pylint` errors:

![image](https://user-images.githubusercontent.com/196840/132099740-2b03278c-c99d-4c23-9b08-2bcd39973acd.png)

By default, Python uses the local encoding and on Windows it is not UTF-8.