### PR TITLE
Add some resiliency to parsers processsing tests nodes

### DIFF
--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -171,7 +171,11 @@ class DbtFolderReader:
             description=column.get("description", ""),
         )
 
-        for test in column.get("tests", []):
+        tests: Optional[Iterable] = column.get("tests", [])
+        if tests is None:
+            tests = []
+
+        for test in tests:
             if isinstance(test, dict):
                 if "relationships" in test:
                     relationships = test["relationships"]

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -193,7 +193,17 @@ class DbtManifestReader:
                     set(child["depends_on"][model_key]) - {model["unique_id"]}
                 )[0]
 
-                fk_target_table_alias = self.manifest[model_key][depends_on_id]["alias"]
+                try:
+                    fk_target_table_alias = self.manifest[model_key][depends_on_id][
+                        "alias"
+                    ]
+                except KeyError:
+                    logging.debug(
+                        "Could not resolve depends on model id %s to a model in manifest",
+                        depends_on_id,
+                    )
+                    continue
+
                 fk_target_schema = self.manifest[model_key][depends_on_id].get(
                     "schema", "public"
                 )


### PR DESCRIPTION
A PR to address Issue #63 

Adds a simple conditional and an exception catch to two parts of the parser codes which can encounter edge cases like those presented in the issue. 