### PR TITLE
Feature/caveats and points of interest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,8 @@ Let's start by defining a short sample ``schema.yml`` as below.
     models:
       - name: stg_users
         description: User records.
+        points_of_interest: Relevant records.
+        caveats: Sensitive information about users.
         columns:
           - name: id
             description: Primary key.

--- a/README.rst
+++ b/README.rst
@@ -67,8 +67,6 @@ Let's start by defining a short sample ``schema.yml`` as below.
     models:
       - name: stg_users
         description: User records.
-        points_of_interest: Relevant records.
-        caveats: Sensitive information about users.
         columns:
           - name: id
             description: Primary key.
@@ -297,6 +295,24 @@ Here are the visibility types supported by Metabase:
 * ``retired`` (supported but not reflected in the UI)
 
 If you notice new ones, please submit a PR to update this readme.
+
+Model extra fields
+----------------
+
+In addition to the model description, metabase accepts two extra information fields. Those optional
+fields are called ``caveats`` and ``points_of_interest`` and can be defined under the ``meta`` tag
+of the model.
+
+This is how you can specify them in the ``stg_users`` example:
+
+.. code-block:: yaml
+
+  - name: stg_users
+    description: User records.
+    meta:
+      metabase.points_of_interest: Relevant records.
+      metabase.caveats: Sensitive information about users.
+
 
 Database Sync
 -------------

--- a/README.rst
+++ b/README.rst
@@ -299,7 +299,7 @@ If you notice new ones, please submit a PR to update this readme.
 Model extra fields
 ----------------
 
-In addition to the model description, metabase accepts two extra information fields. Those optional
+In addition to the model description, Metabase accepts two extra information fields. Those optional
 fields are called ``caveats`` and ``points_of_interest`` and can be defined under the ``meta`` tag
 of the model.
 

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -220,14 +220,22 @@ class MetabaseClient:
             model_description = None
         else:
             model_description = model.description
+        if not model.points_of_interest:
+            model_points_of_interest = None
+        else:
+            model_points_of_interest = model.points_of_interest
+        if not model.caveats:
+            model_caveats = None
+        else:
+            model_caveats = model.caveats
 
         body_table = {}
         if api_table["description"] != model_description:
             body_table["description"] = model_description
-        if api_table["points_of_interest"] != model.points_of_interest:
-            body_table["points_of_interest"] = model.points_of_interest
-        if api_table["caveats"] != model.caveats:
-            body_table["caveats"] = model.caveats
+        if api_table.get("points_of_interest") != model_points_of_interest:
+            body_table["points_of_interest"] = model_points_of_interest
+        if api_table.get("caveats") != model_caveats:
+            body_table["caveats"] = model_caveats
 
         table_id = api_table["id"]
         if bool(body_table):

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -222,12 +222,20 @@ class MetabaseClient:
             model_description = model.description
 
         table_id = api_table["id"]
-        if api_table["description"] != model_description and model_description:
+        if (
+                api_table["description"] != model_description or
+                api_table["points_of_interest"] != model.points_of_interest or
+                api_table["caveats"] != model.caveats
+        ):
             # Update with new values
             self.api(
                 "put",
                 f"/api/table/{table_id}",
-                json={"description": model_description},
+                json={
+                    "description": model_description,
+                    "points_of_interest": model.points_of_interest,
+                    "caveats": model.caveats,
+                },
             )
             logger().info("\n:raising_hands: Updated table %s successfully", lookup_key)
         elif not model_description:

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -221,21 +221,21 @@ class MetabaseClient:
         else:
             model_description = model.description
 
+        body_table = {}
+        if api_table["description"] != model_description:
+            body_table["description"] = model_description
+        if api_table["points_of_interest"] != model.points_of_interest:
+            body_table["points_of_interest"] = model.points_of_interest
+        if api_table["caveats"] != model.caveats:
+            body_table["caveats"] = model.caveats
+
         table_id = api_table["id"]
-        if (
-                api_table["description"] != model_description or
-                api_table["points_of_interest"] != model.points_of_interest or
-                api_table["caveats"] != model.caveats
-        ):
+        if bool(body_table):
             # Update with new values
             self.api(
                 "put",
                 f"/api/table/{table_id}",
-                json={
-                    "description": model_description,
-                    "points_of_interest": model.points_of_interest,
-                    "caveats": model.caveats,
-                },
+                json=body_table,
             )
             logger().info("\n:raising_hands: Updated table %s successfully", lookup_key)
         elif not model_description:

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -32,8 +32,8 @@ class MetabaseModel:
     name: str
     schema: str
     description: str = ""
-    points_of_interest: str = None
-    caveats: str = None
+    points_of_interest: Optional[str] = None
+    caveats: Optional[str] = None
 
     model_type: ModelType = ModelType.nodes
     dbt_name: Optional[str] = None

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -32,6 +32,8 @@ class MetabaseModel:
     name: str
     schema: str
     description: str = ""
+    points_of_interest: str = None
+    caveats: str = None
 
     model_type: ModelType = ModelType.nodes
     dbt_name: Optional[str] = None

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -144,8 +144,9 @@ class DbtFolderReader:
             metabase_columns.append(self._read_column(column, schema))
 
         description = model.get("description", "")
-        points_of_interest = model.get("points_of_interest")
-        caveats = model.get("caveats")
+        meta = model.get("meta")
+        points_of_interest = meta.get("metabase.points_of_interest") if meta else None
+        caveats = meta.get("metabase.caveats") if meta else None
 
         if include_tags:
             tags = model.get("tags", [])

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -144,9 +144,9 @@ class DbtFolderReader:
             metabase_columns.append(self._read_column(column, schema))
 
         description = model.get("description", "")
-        meta = model.get("meta")
-        points_of_interest = meta.get("metabase.points_of_interest") if meta else None
-        caveats = meta.get("metabase.caveats") if meta else None
+        meta = model.get("meta", {})
+        points_of_interest = meta.get("metabase.points_of_interest")
+        caveats = meta.get("metabase.caveats")
 
         if include_tags:
             tags = model.get("tags", [])

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -144,6 +144,8 @@ class DbtFolderReader:
             metabase_columns.append(self._read_column(column, schema))
 
         description = model.get("description", "")
+        points_of_interest = model.get("points_of_interest")
+        caveats = model.get("caveats")
 
         if include_tags:
             tags = model.get("tags", [])
@@ -165,6 +167,8 @@ class DbtFolderReader:
             name=resolved_name,
             schema=schema,
             description=description,
+            points_of_interest=points_of_interest,
+            caveats=caveats,
             columns=metabase_columns,
             model_type=model_type,
             source=source,

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -246,6 +246,9 @@ class DbtManifestReader:
             )
 
         description = model.get("description", "")
+        meta = model.get("meta", {})
+        points_of_interest = meta.get("metabase.points_of_interest")
+        caveats = meta.get("metabase.caveats")
 
         if include_tags:
             tags = model.get("tags", [])
@@ -273,6 +276,8 @@ class DbtManifestReader:
             name=resolved_name,
             schema=model["schema"].upper(),
             description=description,
+            points_of_interest=points_of_interest,
+            caveats=caveats,
             columns=metabase_column,
             model_type=model_type,
             unique_id=unique_id,

--- a/tests/fixtures/sample_project/models/schema.yml
+++ b/tests/fixtures/sample_project/models/schema.yml
@@ -31,6 +31,9 @@ models:
 
   - name: orders
     description: This table has basic information about orders, as well as some derived facts based on payments
+    meta:
+      metabase.points_of_interest: Basic information only
+      metabase.caveats: Some facts are derived from payments
 
     columns:
       - name: order_id

--- a/tests/test_dbt_parsers.py
+++ b/tests/test_dbt_parsers.py
@@ -101,6 +101,8 @@ class TestDbtFolderReader(unittest.TestCase):
                 name="orders",
                 schema="PUBLIC",
                 description="This table has basic information about orders, as well as some derived facts based on payments",
+                points_of_interest="Basic information only",
+                caveats="Some facts are derived from payments",
                 model_type=ModelType.nodes,
                 dbt_name=None,
                 source=None,


### PR DESCRIPTION
## Problem
There are plus two fields on Metabase table's description, which can also be added to this automation. On Metabase they are called “Why this table is interesting“ and “Things to be aware of about this table“.

## Approach
- Added parameters `points_of_interest` and `caveats` to the API call of table (https://www.metabase.com/docs/latest/api-documentation.html#put-apitableid)
- Adjusted README with those two new parameters 
