### PR TITLE
feat: Explore dbt Model

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -715,6 +715,97 @@ def exposures(
     )
 
 
+@cli.command(cls=CommandController)
+@shared_opts
+@click.option(
+    "-m",
+    "--model-name",
+    type=click.STRING,
+    help="Full name of the dbt model to explore in the Metabase UI",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Flag which signals verbose output",
+)
+def explore(
+    metabase_host: str,
+    metabase_user: str,
+    metabase_password: str,
+    metabase_database: str,
+    model_name: str,
+    dbt_database: str,
+    dbt_path: Optional[str] = None,
+    dbt_manifest_path: Optional[str] = None,
+    dbt_schema: Optional[str] = None,
+    dbt_schema_excludes: Optional[Iterable] = None,
+    dbt_includes: Optional[Iterable] = None,
+    dbt_excludes: Optional[Iterable] = None,
+    metabase_use_http: bool = False,
+    metabase_verify: Optional[str] = None,
+    metabase_sync: bool = True,
+    metabase_sync_timeout: Optional[int] = None,
+    verbose: bool = False,
+) -> None:
+    """Compiles dbt model and opens Metabase query UI with compiled SQL pre-populated.
+
+    \f
+    Args:
+        metabase_host (str): Metabase hostname
+        metabase_user (str): Metabase username
+        metabase_password (str): Metabase password
+        metabase_database (str): Target database name as set in Metabase (typically aliased)
+        model_name (str): Full name of the dbt model to explore in the Metabase UI.
+        dbt_database (str):  Target database name as specified in dbt models to be actioned
+        dbt_path (Optional[str], optional): Path to dbt project. If specified with dbt_manifest_path, then the manifest is prioritized. Defaults to None.
+        dbt_manifest_path (Optional[str], optional): Path to dbt manifest.json file (typically located in the /target/ directory of the dbt project). Defaults to None.
+        dbt_schema (Optional[str], optional): Target schema. Should be passed if using folder parser. Defaults to None.
+        dbt_schema_excludes (Optional[Iterable], optional): Target schemas to exclude. Ignored in folder parser. Defaults to None.
+        dbt_includes (Optional[Iterable], optional): Model names to limit processing to. Defaults to None.
+        dbt_excludes (Optional[Iterable], optional): Model names to exclude. Defaults to None.
+        metabase_use_http (bool, optional): Use HTTP to connect to Metabase. Defaults to False.
+        metabase_verify (Optional[str], optional): Path to custom certificate bundle to be used by Metabase client. Defaults to None.
+        metabase_sync (bool, optional): Attempt to synchronize Metabase schema with local models. Defaults to True.
+        metabase_sync_timeout (Optional[int], optional): Synchronization timeout (in secs). If set, we will fail hard on synchronization failure; if not set, we will proceed after attempting sync regardless of success. Only valid if sync is enabled. Defaults to None.
+        verbose (bool, optional): Flag which signals verbose output. Defaults to False.
+    """
+
+    # Set global logging level if verbose
+    if verbose:
+        package_logger.LOGGING_LEVEL = logging.DEBUG
+
+    # Instantiate dbt interface
+    dbt = DbtInterface(
+        path=dbt_path,
+        manifest_path=dbt_manifest_path,
+        database=dbt_database,
+        schema=dbt_schema,
+        schema_excludes=dbt_schema_excludes,
+        includes=dbt_includes,
+        excludes=dbt_excludes,
+    )
+
+    # Compile model
+    compiled_sql = dbt.compile_model(model_name)
+
+    # Instantiate Metabase interface
+    metabase = MetabaseInterface(
+        host=metabase_host,
+        user=metabase_user,
+        password=metabase_password,
+        use_http=metabase_use_http,
+        verify=metabase_verify,
+        database=metabase_database,
+        sync=metabase_sync,
+        sync_timeout=metabase_sync_timeout,
+    )
+
+    # Load client
+    metabase.prepare_metabase_client()
+    metabase.client.explore_query(metabase.database, compiled_sql)
+
+
 def main():
     # Valid kwarg
     cli(max_content_width=600)  # pylint: disable=unexpected-keyword-arg

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -809,7 +809,17 @@ class MetabaseClient:
             ],
         }
 
-    def explore_query(self, database, query):
+    def explore_query(self, database: str, query: str) -> None:
+        """Allows a user to open a model in the Metabase query editor to expedite the process
+        of testing models against production sources, visualizing model distributions, etc.
+
+        Arguments:
+            database {str} -- Metabase database name.
+            query {str} -- A SQL query to be opened in Metabase
+
+        Returns:
+            None
+        """
         exploratory_interface = {
             "dataset_query": {
                 "database": self.find_database_id(database),

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -1,6 +1,8 @@
 import re
 import json
 import requests
+import webbrowser
+import base64
 import time
 import yaml
 import os
@@ -790,6 +792,20 @@ class MetabaseClient:
                 if exposure.upper() in refable_models
             ],
         }
+
+    def explore_query(self, database, query):
+        exploratory_interface = {
+            "dataset_query": {
+                "database": self.find_database_id(database),
+                "native": {"query": query, "template-tags": {}},
+                "type": "native",
+            },
+            "display": "table",
+            "visualization_settings": {},
+        }
+        webbrowser.open(
+            f"{self.protocol}://{self.host}/question#{str(base64.b64encode(json.dumps(exploratory_interface).encode('utf-8')), 'utf-8')}"
+        )
 
     def api(
         self,

--- a/dbtmetabase/models/exceptions.py
+++ b/dbtmetabase/models/exceptions.py
@@ -16,3 +16,7 @@ class MetabaseUnableToSync(Exception):
 
 class DbtParserNotInstantiated(Exception):
     """Thrown when trying to access dbt reader from interface prior to instantiation via class method"""
+
+
+class ModelNotFound(Exception):
+    """Thrown when model is not found in manifest after successful compile command"""

--- a/dbtmetabase/models/interface.py
+++ b/dbtmetabase/models/interface.py
@@ -12,7 +12,6 @@ from .exceptions import (
     NoDbtSchemaSupplied,
     MetabaseClientNotInstantiated,
     DbtParserNotInstantiated,
-    MetabaseUnableToSync,
     ModelNotFound,
 )
 from ..parsers.dbt_folder import DbtFolderReader
@@ -51,8 +50,6 @@ class MetabaseInterface(MetabaseConfig):
         Args:
             dbt_models (Optional[List[MetabaseModel]]): Used if sync is enabled to verify all dbt models passed exist in Metabase
 
-        Raises:
-            MetabaseUnableToSync: This error is raised if sync is enabled and a timeout is explicitly set in the `Metabase` object config
         """
         if dbt_models is None:
             dbt_models = []


### PR DESCRIPTION
This PR will add a command that allows users to test, develop, explore, and "workbench" models in Metabase's robust query editor with a single CLI invocation removing any repetitive tasks that occur between updating a model and quickly testing it against a data warehouse.

`dbt-metabase explore --model fct_core_customer`

`dbt-metabase explore --model fct_core_customer --target production`

This PR is in a working state as-is. 

- [x] Reduce passable args to explore command (no need for default shared opts)
- [x] Add vscode command pallete instructions (potentially)
- [ ] Update docs

Linked issue #78 