### PR TITLE
Fix README.rst that broke the build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6.x'
+          python-version: "3.6.x"
 
       - name: Requirements
         run: make requirements
@@ -27,8 +27,11 @@ jobs:
       - name: Formatting check (black)
         run: make check-fmt
 
-      - name: Lint check (pylint)
-        run: make check-lint
+      - name: Lint Python check (pylint)
+        run: make check-lint-python
+
+      - name: Lint reStructuredText check (rst-lint)
+        run: make check-lint-rst
 
       - name: Type check (mypy)
         run: make check-type

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6.x'
+          python-version: "3.6.x"
 
       - uses: actions/cache@v2
         with:
@@ -31,8 +31,11 @@ jobs:
       - name: Formatting check (black)
         run: make check-fmt
 
-      - name: Lint check (pylint)
-        run: make check-lint
+      - name: Lint Python check (pylint)
+        run: make check-lint-python
+
+      - name: Lint reStructuredText check (rst-lint)
+        run: make check-lint-rst
 
       - name: Type check (mypy)
         run: make check-type

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,20 @@ check-fmt:
 	black --check .
 .PHONY: check-fmt
 
-check-lint:
+check-lint-python:
 	pylint dbtmetabase
-.PHONY: check-lint
+.PHONY: check-lint-python
+
+check-lint-rst:
+	pylint dbtmetabase
+.PHONY: check-lint-rst
 
 check-type:
 	mypy dbtmetabase
 .PHONY: check-type
+
+check: check-fmt check-lint-python check-lint-rst check-type
+.PHONY: check
 
 test:
 	python3 -m unittest tests

--- a/README.rst
+++ b/README.rst
@@ -296,8 +296,8 @@ Here are the visibility types supported by Metabase:
 
 If you notice new ones, please submit a PR to update this readme.
 
-Model extra fields
-----------------
+Model Extra Fields
+------------------
 
 In addition to the model description, Metabase accepts two extra information fields. Those optional
 fields are called ``caveats`` and ``points_of_interest`` and can be defined under the ``meta`` tag

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@ mypy
 types-requests
 types-PyYAML
 black
+restructuredtext-lint


### PR DESCRIPTION
Fix improperly formatted heading in README.rst (#76) and add reStructuredText linter to prevent this in future.

CI run: https://github.com/gouline/dbt-metabase/runs/4345047264

FYI @patygold 