### PR TITLE
Expose interfaces in models

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -11,7 +11,7 @@ from .logger import logging as package_logger
 from .models.interface import MetabaseInterface, DbtInterface
 from .utils import get_version, load_config
 
-
+__all__ = ["MetabaseInterface", "DbtInterface"]
 __version__ = get_version()
 
 CONFIG = load_config()


### PR DESCRIPTION
Allow imports like this for programmatic instantiation:

```python
from dbtmetabase import DbtInterface, MetabaseInterface
```

Instead of:

```python
from dbtmetabase.models.interface import DbtInterface, MetabaseInterface
```