### PR TITLE
Feat: Enable using dbt meta to set FK relationships

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ how our dbt models are exposed in BI which closes the loop between ELT, modellin
         --output_path ./models/ \
         --output_name metabase_exposures
 
-Once execution completes, a look at the output ``metabase_exposures.yml`` will 
+Once execution completes, a look at the output ``metabase_exposures.yml`` will
 reveal all metabase exposures documented with the documentation, descriptions, creator
 emails & names, links to exposures, and even native SQL propagated over from Metabase.
 
@@ -145,13 +145,13 @@ emails & names, links to exposures, and even native SQL propagated over from Met
       - name: Number_of_orders_over_time
         description: '
           ### Visualization: Line
-      
+
           A line chart depicting how order volume changes over time
-      
+
           #### Metadata
-      
+
           Metabase Id: __8__
-      
+
           Created On: __2021-07-21T08:01:38.016244Z__'
         type: analysis
         url: http://your.metabase.com/card/8
@@ -164,7 +164,7 @@ emails & names, links to exposures, and even native SQL propagated over from Met
 
 Questions which are native queries will have the SQL propagated to a code block in the documentation's
 description for full visibility. This YAML, like the rest of your dbt project can be committed to source
-control to understand how exposures change over time. In a production environment, one can trigger 
+control to understand how exposures change over time. In a production environment, one can trigger
 ``dbt docs generate`` after ``dbt-metabase exposures`` (or alternatively run the exposure extraction job
 on a cadence every X days) in order to keep a dbt docs site fully synchronized with BI. This makes ``dbt docs`` a
 useful utility for introspecting the data model from source -> consumption with zero extra/repeated human input.
@@ -270,6 +270,31 @@ Here is the list of semantic types (formerly known as special types) currently a
 
 If you notice new ones, please submit a PR to update this readme.
 
+Foreign Keys
+------------
+
+By default, dbt-metabase parses the relationship tests to figure out PK-FK
+relationships between two tables. Alternatively, you can also use the meta
+fields ``fk_target_table`` and ``fk_target_field`` to set the relationships
+just like semantic types. You can set the ``semantic_type`` as ``type/FK``
+without setting those two fields, but you cannot set those two fields
+without the ``semantic_type`` set to ``type/FK``.
+
+Here is an example of how you could to this:
+
+.. code-block:: yaml
+
+    - name: country_id
+      description: FK to User's country in the dim_countries table.
+      meta:
+        metabase.semantic_type: type/FK
+        metabase.fk_target_table: analytics_dims.dim_countries
+        metabase.fk_target_field: id
+
+Importantly, the ``fk_target_table`` needs to be in the format
+``schema_name.table_name``. If the model has an alias, use the alias, not
+the original model name here.
+
 Visibility Types
 ----------------
 
@@ -335,10 +360,10 @@ Configuration
     dbt-metabase config
 
 Using the above command, you can enter an interactive configuration session where you can cache default selections
-for arguments. This creates a ``config.yml`` in ~/.dbt-metabase. This is particularly useful for arguments which are repeated on every invocation like metabase_user, metabase_host, 
-metabase_password, dbt_manifest_path, etc. 
+for arguments. This creates a ``config.yml`` in ~/.dbt-metabase. This is particularly useful for arguments which are repeated on every invocation like metabase_user, metabase_host,
+metabase_password, dbt_manifest_path, etc.
 
-In addition, there are a few injected env vars that make deploying dbt-metabase in a CI/CD environment simpler without exposing 
+In addition, there are a few injected env vars that make deploying dbt-metabase in a CI/CD environment simpler without exposing
 secrets. Listed below are acceptable env vars which correspond to their CLI flags:
 
 * ``DBT_DATABASE``
@@ -350,10 +375,10 @@ secrets. Listed below are acceptable env vars which correspond to their CLI flag
 * ``MB_DATABASE``
 
 If any one of the above is present in the environment, the corresponding CLI flag is not needed unless overriding
-the environment value. In the absence of a CLI flag, dbt-metabase will first look to the environment for any 
+the environment value. In the absence of a CLI flag, dbt-metabase will first look to the environment for any
 env vars to inject, then we will look to the config.yml for cached defaults.
 
-A ``config.yml`` can be created or updated manually as well if needed. The only 
+A ``config.yml`` can be created or updated manually as well if needed. The only
 requirement is that it must be located in ~/.dbt-metabase. The layout is as follows:
 
 .. code-block:: yaml

--- a/README.rst
+++ b/README.rst
@@ -278,7 +278,9 @@ relationships between two tables. Alternatively, you can also use the meta
 fields ``fk_target_table`` and ``fk_target_field`` to set the relationships
 just like semantic types. You can set the ``semantic_type`` as ``type/FK``
 without setting those two fields, but you cannot set those two fields
-without the ``semantic_type`` set to ``type/FK``.
+without the ``semantic_type`` set to ``type/FK``. If both the meta fields
+and a relationships test are set for a field, the information supplied by
+the meta fields takes precedence.
 
 Here is an example of how you could to this:
 

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -5,7 +5,13 @@ from typing import Sequence, Optional, MutableMapping
 
 # Allowed metabase.* fields
 # Should be covered by attributes in the MetabaseColumn class
-METABASE_META_FIELDS = ["special_type", "semantic_type", "visibility_type"]
+METABASE_META_FIELDS = [
+    "special_type",
+    "semantic_type",
+    "visibility_type",
+    "fk_target_table",
+    "fk_target_field",
+]
 
 
 class ModelType(str, Enum):


### PR DESCRIPTION
Rationale for this PR: I've had my fair share of issues with setting the PK/FK relationships via the dbt relationships test. My current issue is that the existing logic is a two-way street and which field in a relationship is set as PK and which as FK is basically random.

This is because the manifest's `child_map` contains relationships for both the tested field as well as the related model. This is sort-of OK because if the fields are named differently (e.g. `orders.customer_id` vs `customers.id`), the un-intended relationship is not actually set because it can't find the field. However, if following a different convention (i.e. `orders.customer_id` and `customers.customer_id`), this isn't the case anymore, and the PK and FK fields may be switched up.

Instead of trying to fix the whole thing in the code base, I thought it wouldn't harm to just allow setting relationships via `meta` instead of forcing the user to set relationship tests (among other things, because a user may not _want_ to use those tests in production to begin with for various reasons). Hence, this PR.