### PR TITLE
feat: Add flag to skip syncing sources, and allow meta-defined display names

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -500,6 +500,11 @@ def config(ctx, inspect: bool = False, resolve: bool = False, env: bool = False)
     help="Flag to append tags to table descriptions in Metabase (default False)",
 )
 @click.option(
+    "--metabase_sync_sources",
+    is_flag=True,
+    help="If True, try to sync dbt sources to Metabase. Defaults to False.",
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -520,6 +525,7 @@ def models(
     metabase_use_http: bool = False,
     metabase_verify: Optional[str] = None,
     metabase_sync: bool = True,
+    metabase_sync_sources: bool = False,
     metabase_sync_timeout: Optional[int] = None,
     dbt_include_tags: bool = True,
     dbt_docs_url: Optional[str] = None,
@@ -543,6 +549,7 @@ def models(
         metabase_verify (Optional[str], optional): Path to custom certificate bundle to be used by Metabase client. Defaults to None.
         metabase_sync (bool, optional): Attempt to synchronize Metabase schema with local models. Defaults to True.
         metabase_sync_timeout (Optional[int], optional): Synchronization timeout (in secs). If set, we will fail hard on synchronization failure; if not set, we will proceed after attempting sync regardless of success. Only valid if sync is enabled. Defaults to None.
+        metabase_sync_sources (bool, optional): If True, try to sync dbt sources to Metabase. Defaults to False.
         dbt_include_tags (bool, optional): Flag to append tags to table descriptions in Metabase. Defaults to True.
         dbt_docs_url (Optional[str], optional): Pass in URL to dbt docs site. Appends dbt docs URL for each model to Metabase table description. Defaults to None.
         verbose (bool, optional): Flag which signals verbose output. Defaults to False.
@@ -579,6 +586,7 @@ def models(
         database=metabase_database,
         sync=metabase_sync,
         sync_timeout=metabase_sync_timeout,
+        include_sources=metabase_sync_sources,
     )
 
     # Load client

--- a/dbtmetabase/logger/logging.py
+++ b/dbtmetabase/logger/logging.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 from functools import lru_cache
 from pathlib import Path

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -229,10 +229,12 @@ class MetabaseClient:
             return
 
         # Empty strings not accepted by Metabase
+        model_display_name = model.display_name or None
         if not model.description:
             model_description = None
         else:
-            model_description = model.description
+            # We want to always convert newlines to spaces
+            model_description = model.description.replace("\n", " ")
         if not model.points_of_interest:
             model_points_of_interest = None
         else:
@@ -243,6 +245,8 @@ class MetabaseClient:
             model_caveats = model.caveats
 
         body_table = {}
+        if api_table["display_name"] != model_display_name:
+            body_table["display_name"] = model_display_name
         if api_table["description"] != model_description:
             body_table["description"] = model_description
         if api_table.get("points_of_interest") != model_points_of_interest:

--- a/dbtmetabase/models/interface.py
+++ b/dbtmetabase/models/interface.py
@@ -25,6 +25,7 @@ class MetabaseInterface:
         verify: Optional[Union[str, bool]] = True,
         sync: bool = True,
         sync_timeout: Optional[int] = None,
+        include_sources: bool = False,
     ):
         """Constructor.
 
@@ -50,6 +51,7 @@ class MetabaseInterface:
         # Metabase Sync
         self.sync = sync
         self.sync_timeout = sync_timeout
+        self.include_sources = include_sources
 
     @property
     def client(self) -> MetabaseClient:
@@ -81,6 +83,7 @@ class MetabaseInterface:
             password=self.password,
             use_http=self.use_http,
             verify=self.verify,
+            include_sources=self.include_sources,
         )
 
         # Sync and attempt schema alignment prior to execution; if timeout is not explicitly set, proceed regardless of success

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -38,6 +38,7 @@ class MetabaseModel:
     name: str
     schema: str
     description: str = ""
+    display_name: str = ""
     points_of_interest: Optional[str] = None
     caveats: Optional[str] = None
 

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -145,6 +145,7 @@ class DbtFolderReader(DbtReader):
 
         # Resolved name is what the name will be in the database
         resolved_name = model.get("alias", model.get("identifier"))
+        display_name = meta.get("metabase.display_name")
         dbt_name = None
         if not resolved_name:
             resolved_name = model["name"]
@@ -153,6 +154,7 @@ class DbtFolderReader(DbtReader):
 
         return MetabaseModel(
             name=resolved_name,
+            display_name=display_name,
             schema=schema,
             description=description,
             points_of_interest=points_of_interest,


### PR DESCRIPTION
This tool is amazing!

I have a couple features that may be helpful.

First, adding a flag to skip all dbt sources. In [our project](https://github.com/cal-itp/data-infra/tree/main/warehouse), we ultimately use Metabase on top of BigQuery, but we don't import source datasets into Metabase. Without the flag, `dbt-metabase` throws errors as it tries to sync dbt source models.

Second, adding `metabase.display_name` as an optional field. We deal with a lot of [GTFS](https://gtfs.org/) data, so our model names naturally have GTFS as a common acronym. Currently it gets title-cased as `Gtfs` in many situations, which is annoying. So I wanted to have the ability to override the Metabase `display_name` property.