### PR TITLE
Makes native query model extraction case-insensitive, and work on qualified table names.

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -268,7 +268,6 @@ def shared_opts(func: Callable) -> Callable:
 @click.version_option(__version__)
 def cli():
     """Model synchronization from dbt to Metabase."""
-    ...
 
 
 @click.command(cls=CommandController)

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -713,7 +713,7 @@ class MetabaseClient:
         elif query.get("type") == "native":
             # Metabase native query
             native_query = query.get("native").get("query")
-            ctes = []
+            ctes: List[str] = []
 
             # Parse common table expressions for exclusion
             for matched_cte in re.findall(self.cte_parser, native_query):


### PR DESCRIPTION
This is a fix for #97.

* The `self.exposure_parser` regex will now match (most) qualified table names.
    * There are some edge cases I don't account for, like quoted names with spaces.
* The exposure extractor is now case insensitive. 
* I excluded qualified names from the CTE scrubbing code, so that exposures can correctly detect things like `with name as (select * from real_data.name)`.

### Testing
* `make test` passes
* I ran my version against a fairly large (600 question) metabase instance, and confirmed that it detected the expected exposure dependencies.