### PR TITLE
Add `display_name` option for field names

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -525,6 +525,11 @@ def config(ctx, inspect: bool = False, resolve: bool = False, env: bool = False)
     help="Flag to append tags to table descriptions in Metabase (default False)",
 )
 @click.option(
+    "--metabase_exclude_sources",
+    is_flag=True,
+    help="Flag to skip exporting sources to Metabase (default False)",
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -546,10 +551,11 @@ def models(
     metabase_verify: Optional[str] = None,
     metabase_sync: bool = True,
     metabase_sync_timeout: Optional[int] = None,
+    metabase_exclude_sources: bool = False,
     dbt_include_tags: bool = True,
     dbt_docs_url: Optional[str] = None,
     verbose: bool = False,
-) -> None:
+):
     """Exports model documentation and semantic types from dbt to Metabase.
 
     Args:
@@ -568,6 +574,7 @@ def models(
         metabase_verify (Optional[str], optional): Path to custom certificate bundle to be used by Metabase client. Defaults to None.
         metabase_sync (bool, optional): Attempt to synchronize Metabase schema with local models. Defaults to True.
         metabase_sync_timeout (Optional[int], optional): Synchronization timeout (in secs). If set, we will fail hard on synchronization failure; if not set, we will proceed after attempting sync regardless of success. Only valid if sync is enabled. Defaults to None.
+        metabase_exclude_sources (bool, optional): Flag to skip exporting sources to Metabase. Defaults to False.
         dbt_include_tags (bool, optional): Flag to append tags to table descriptions in Metabase. Defaults to True.
         dbt_docs_url (Optional[str], optional): Pass in URL to dbt docs site. Appends dbt docs URL for each model to Metabase table description. Defaults to None.
         verbose (bool, optional): Flag which signals verbose output. Defaults to False.
@@ -604,6 +611,7 @@ def models(
         database=metabase_database,
         sync=metabase_sync,
         sync_timeout=metabase_sync_timeout,
+        exclude_sources=metabase_exclude_sources,
     )
 
     # Load client

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -388,12 +388,19 @@ class MetabaseClient:
         else:
             column_description = column.description
 
+        # Empty strings not accepted by Metabase
+        if not column.display_name:
+            display_name = None
+        else:
+            display_name = column.display_name
+
         # Preserve this relationship by default
         if api_field["fk_target_field_id"] is not None and fk_target_field_id is None:
             fk_target_field_id = api_field["fk_target_field_id"]
 
         if (
             api_field["description"] != column_description
+            or api_field["display_name"] != display_name
             or api_field[semantic_type] != column.semantic_type
             or api_field["visibility_type"] != column.visibility_type
             or api_field["fk_target_field_id"] != fk_target_field_id
@@ -404,6 +411,7 @@ class MetabaseClient:
                 f"/api/field/{field_id}",
                 json={
                     "description": column_description,
+                    "display_name": display_name,
                     semantic_type: column.semantic_type,
                     "visibility_type": column.visibility_type,
                     "fk_target_field_id": fk_target_field_id,

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -595,9 +595,8 @@ class MetabaseClient:
                     try:
                         creator = self.api("get", f"/api/user/{exposure['creator_id']}")
                     except requests.exceptions.HTTPError as error:
-                        if error.response.status_code == 404:
-                            creator = {}
-                        else:
+                        creator = {}
+                        if error.response.status_code != 404:
                             raise
 
                     creator_email = creator.get("email")

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -19,7 +19,7 @@ from typing import (
 from dbtmetabase.models import exceptions
 
 from .logger.logging import logger
-from .models.metabase import MetabaseModel, MetabaseColumn
+from .models.metabase import MetabaseModel, MetabaseColumn, ModelType
 
 
 class MetabaseClient:
@@ -35,6 +35,7 @@ class MetabaseClient:
         use_http: bool = False,
         verify: Union[str, bool] = None,
         session_id: str = None,
+        exclude_sources: bool = False,
     ):
         """Constructor.
 
@@ -47,12 +48,14 @@ class MetabaseClient:
             use_http {bool} -- Use HTTP instead of HTTPS. (default: {False})
             verify {Union[str, bool]} -- Path to certificate or disable verification. (default: {None})
             session_id {str} -- Metabase session ID. (default: {None})
+            exclude_sources {bool} -- Exclude exporting sources. (default: {False})
         """
 
         self.host = host
         self.protocol = "http" if use_http else "https"
         self.verify = verify
         self.session_id = session_id or self.get_session_id(user, password)
+        self.exclude_sources = exclude_sources
         self.collections: Iterable = []
         self.tables: Iterable = []
         self.table_map: MutableMapping = {}
@@ -142,7 +145,9 @@ class MetabaseClient:
             )
         return sync_successful
 
-    def models_compatible(self, database_id: str, models: Sequence) -> bool:
+    def models_compatible(
+        self, database_id: str, models: Sequence[MetabaseModel]
+    ) -> bool:
         """Checks if models compatible with the Metabase database schema.
 
         Arguments:
@@ -157,6 +162,8 @@ class MetabaseClient:
 
         are_models_compatible = True
         for model in models:
+            if model.model_type == ModelType.sources and self.exclude_sources:
+                continue
 
             schema_name = model.schema.upper()
             model_name = model.name.upper()
@@ -202,6 +209,10 @@ class MetabaseClient:
         table_lookup, field_lookup = self.build_metadata_lookups(database_id)
 
         for model in models:
+            if model.model_type == ModelType.sources and self.exclude_sources:
+                logger().info(":fast_forward: Skipping %s source", model.unique_id)
+                continue
+
             self.export_model(model, table_lookup, field_lookup, aliases)
 
     def export_model(
@@ -233,12 +244,15 @@ class MetabaseClient:
             return
 
         # Empty strings not accepted by Metabase
+        model_display_name = model.display_name or None
         model_description = model.description or None
         model_points_of_interest = model.points_of_interest or None
         model_caveats = model.caveats or None
         model_visibility = model.visibility_type or "normal"
 
         body_table = {}
+        if api_table.get("display_name") != model_display_name:
+            body_table["display_name"] = model_display_name
         if api_table.get("description") != model_description:
             body_table["description"] = model_description
         if api_table.get("points_of_interest") != model_points_of_interest:

--- a/dbtmetabase/models/interface.py
+++ b/dbtmetabase/models/interface.py
@@ -26,6 +26,7 @@ class MetabaseInterface:
         verify: Optional[Union[str, bool]] = True,
         sync: bool = True,
         sync_timeout: Optional[int] = None,
+        exclude_sources: bool = False,
     ):
         """Constructor.
 
@@ -39,6 +40,7 @@ class MetabaseInterface:
             verify (Optional[Union[str, bool]], optional): Path to custom certificate bundle to be used by Metabase client. Defaults to True.
             sync (bool, optional): Attempt to synchronize Metabase schema with local models. Defaults to True.
             sync_timeout (Optional[int], optional): Synchronization timeout (in secs). Defaults to None.
+            exclude_sources (bool, optional): Exclude exporting sources. Defaults to False.
         """
 
         # Metabase Client
@@ -53,6 +55,7 @@ class MetabaseInterface:
         # Metabase Sync
         self.sync = sync
         self.sync_timeout = sync_timeout
+        self.exclude_sources = exclude_sources
 
     @property
     def client(self) -> MetabaseClient:
@@ -85,6 +88,7 @@ class MetabaseInterface:
             use_http=self.use_http,
             verify=self.verify,
             session_id=self.session_id,
+            exclude_sources=self.exclude_sources,
         )
 
         # Sync and attempt schema alignment prior to execution; if timeout is not explicitly set, proceed regardless of success

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -38,6 +38,7 @@ class MetabaseModel:
     name: str
     schema: str
     description: str = ""
+    display_name: Optional[str] = None
     points_of_interest: Optional[str] = None
     caveats: Optional[str] = None
 

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -23,6 +23,7 @@ class ModelType(str, Enum):
 class MetabaseColumn:
     name: str
     description: Optional[str] = None
+    display_name: Optional[str] = None
 
     meta_fields: MutableMapping = field(default_factory=dict)
 

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -145,6 +145,7 @@ class DbtFolderReader(DbtReader):
 
         # Resolved name is what the name will be in the database
         resolved_name = model.get("alias", model.get("identifier"))
+        display_name = meta.get("metabase.display_name")
         dbt_name = None
         if not resolved_name:
             resolved_name = model["name"]
@@ -153,6 +154,7 @@ class DbtFolderReader(DbtReader):
 
         return MetabaseModel(
             name=resolved_name,
+            display_name=display_name,
             schema=schema,
             description=description,
             points_of_interest=points_of_interest,

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -198,9 +198,12 @@ class DbtManifestReader(DbtReader):
                 # would return the ref() written in the test, but if the model has an alias, that's not enough.
                 # It is better to use child['depends_on']['nodes'] and exclude the current model
 
-                depends_on_id = list(
-                    set(child["depends_on"][model_type]) - {model["unique_id"]}
-                )[0]
+                depends_on_ids = set(child["depends_on"][model_type])
+                depends_on_ids.discard(model["unique_id"])
+                if not depends_on_ids:
+                    continue
+
+                depends_on_id = depends_on_ids.pop()
 
                 foreign_key_model = manifest[model_type].get(depends_on_id, {})
                 fk_target_table_alias = foreign_key_model.get(

--- a/tests/fixtures/sample_project/models/schema.yml
+++ b/tests/fixtures/sample_project/models/schema.yml
@@ -27,6 +27,8 @@ models:
 
       - name: number_of_orders
         description: Count of the number of orders a customer has placed
+        meta:
+          metabase.display_name: order_count
 
       - name: total_order_amount
         description: Total value (AUD) of a customer's orders

--- a/tests/fixtures/sample_project/models/schema.yml
+++ b/tests/fixtures/sample_project/models/schema.yml
@@ -3,6 +3,8 @@ version: 2
 models:
   - name: customers
     description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+    meta:
+      metabase.display_name: clients
 
     columns:
       - name: customer_id

--- a/tests/test_dbt_parsers.py
+++ b/tests/test_dbt_parsers.py
@@ -81,7 +81,7 @@ class TestDbtFolderReader(unittest.TestCase):
                     MetabaseColumn(
                         name="NUMBER_OF_ORDERS",
                         description="Count of the number of orders a customer has placed",
-                        meta_fields={'display_name': 'order_count'},
+                        meta_fields={"display_name": "order_count"},
                         semantic_type=None,
                         visibility_type=None,
                         fk_target_table=None,

--- a/tests/test_dbt_parsers.py
+++ b/tests/test_dbt_parsers.py
@@ -25,6 +25,7 @@ class TestDbtFolderReader(unittest.TestCase):
         expectation = [
             MetabaseModel(
                 name="customers",
+                display_name="clients",
                 schema="PUBLIC",
                 description="This table has basic information about a customer, as well as some derived facts based on a customer's orders",
                 model_type=ModelType.nodes,

--- a/tests/test_dbt_parsers.py
+++ b/tests/test_dbt_parsers.py
@@ -81,7 +81,7 @@ class TestDbtFolderReader(unittest.TestCase):
                     MetabaseColumn(
                         name="NUMBER_OF_ORDERS",
                         description="Count of the number of orders a customer has placed",
-                        meta_fields={},
+                        meta_fields={'display_name': 'order_count'},
                         semantic_type=None,
                         visibility_type=None,
                         fk_target_table=None,

--- a/tests/test_metabase.py
+++ b/tests/test_metabase.py
@@ -155,7 +155,7 @@ MODELS = [
             MetabaseColumn(
                 name="NUMBER_OF_ORDERS",
                 description="Count of the number of orders a customer has placed",
-                meta_fields={},
+                meta_fields={"display_name": "order_count"},
                 semantic_type=None,
                 visibility_type=None,
                 fk_target_table=None,


### PR DESCRIPTION
Piggybacking off https://github.com/gouline/dbt-metabase/pull/109/files - add the ability to use display_name for fields

https://www.metabase.com/docs/latest/api/field.html#params-12