### PR TITLE
Improve debug message when skipping due to wrong target database

### DIFF
--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -57,7 +57,10 @@ class DbtManifestReader(DbtReader):
             if node["database"].upper() != database.upper():
                 # Skip model not associated with target database
                 logger().debug(
-                    "Skipping %s in database %s, not in target database %s", model_name, node["database"], database
+                    "Skipping %s in database %s, not in target database %s",
+                    model_name,
+                    node["database"],
+                    database,
                 )
                 continue
 

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -57,7 +57,7 @@ class DbtManifestReader(DbtReader):
             if node["database"].upper() != database.upper():
                 # Skip model not associated with target database
                 logger().debug(
-                    "Skipping %s not in target database %s", model_name, database
+                    "Skipping %s in database %s, not in target database %s", model_name, node["database"], database
                 )
                 continue
 


### PR DESCRIPTION
It wasn't at all clear to me what 'dbt database' should be set to - I had guessed it was the dbt profile - so this will help people figure out what we're seeing that we don't expect.