### PR TITLE
feat: allow self reference

### DIFF
--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -185,7 +185,9 @@ class DbtManifestReader(DbtReader):
 
         metabase_column: List[MetabaseColumn] = []
 
-        children = manifest["child_map"][model["unique_id"]]
+        unique_id = model["unique_id"]
+
+        children = manifest["child_map"][unique_id]
         relationship_tests = {}
 
         for child_id in children:
@@ -205,19 +207,30 @@ class DbtManifestReader(DbtReader):
                 # Note, sometimes only the referenced model is returned.
                 depends_on_nodes = list(child["depends_on"][model_type])
                 if len(depends_on_nodes) > 2:
-                    logger().warning(f'Expected at most two nodes, got {len(depends_on_nodes)} nodes, skipping {model["unique_id"]}')
+                    logger().warning(
+                        "Expected at most two nodes, got %d {} nodes, skipping %s {}",
+                        len(depends_on_nodes),
+                        unique_id,
+                    )
                     continue
 
-                # Remove the current model from the list. Note, remove() only removes the first occurence. This ensures
+                # Remove the current model from the list. Note, remove() only removes the first occurrence. This ensures
                 # the logic also works for self referencing models.
                 try:
-                    depends_on_nodes.remove(model["unique_id"])
+                    depends_on_nodes.remove(unique_id)
                 except KeyError:
-                    logger().warning(f'Expected nodes to contain current model, skipping {model["unique_id"]}')
+                    logger().warning(
+                        "Expected nodes to contain current model, skipping %s",
+                        unique_id,
+                    )
                     continue
 
-                if not any(depends_on_nodes):
-                    logger().warning(f'Expected single node after filtering, got {len(depends_on_nodes)} nodes, skipping {model["unique_id"]}')
+                if not depends_on_nodes:
+                    logger().warning(
+                        "Expected single node after filtering, got %d nodes, skipping %s",
+                        len(depends_on_nodes),
+                        unique_id,
+                    )
                     continue
 
                 depends_on_id = depends_on_nodes[0]
@@ -266,7 +279,6 @@ class DbtManifestReader(DbtReader):
                     description += "\n\n"
                 description += f"Tags: {tags}"
 
-        unique_id = model["unique_id"]
         if docs_url:
             full_path = f"{docs_url}/#!/model/{unique_id}"
             if description != "":

--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -216,16 +216,10 @@ class DbtManifestReader(DbtReader):
 
                 # Remove the current model from the list. Note, remove() only removes the first occurrence. This ensures
                 # the logic also works for self referencing models.
-                try:
+                if len(depends_on_nodes) == 2 and unique_id in depends_on_nodes:
                     depends_on_nodes.remove(unique_id)
-                except KeyError:
-                    logger().warning(
-                        "Expected nodes to contain current model, skipping %s",
-                        unique_id,
-                    )
-                    continue
 
-                if not depends_on_nodes:
+                if len(depends_on_nodes) != 1:
                     logger().warning(
                         "Expected single node after filtering, got %d nodes, skipping %s",
                         len(depends_on_nodes),


### PR DESCRIPTION
New approach of #110. This logic now allows the self reference / circular reference. 

I made this logic based on my initial work (i.e., before refactor of @gouline). By removing the set, it's now possible to have a self reference. In addition, as some assumptions are made I added some warning logger if in future dbt manifest changes.

Resolves #74