### PR TITLE
docs: The correct ENV var is MB_PASSWORD (#133)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -355,7 +355,7 @@ secrets. Listed below are acceptable env vars which correspond to their CLI flag
 * ``DBT_PATH``
 * ``DBT_MANIFEST_PATH``
 * ``MB_USER``
-* ``MB_PASS``
+* ``MB_PASSWORD``
 * ``MB_HOST``
 * ``MB_DATABASE``
 

--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -20,7 +20,7 @@ ENV_VARS = [
     "DBT_PATH",
     "DBT_MANIFEST_PATH",
     "MB_USER",
-    "MB_PASS",
+    "MB_PASSWORD",
     "MB_HOST",
     "MB_DATABASE",
     "MB_SESSION_TOKEN",


### PR DESCRIPTION
Fixes #133.