### PR TITLE
fix: Unnecessary updates because of display_name and settings

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -3,6 +3,7 @@ import os
 import re
 import time
 from typing import (
+    Any,
     Iterable,
     List,
     Mapping,
@@ -394,7 +395,7 @@ class MetabaseClient:
         if api_field["fk_target_field_id"] and not fk_target_field_id:
             fk_target_field_id = api_field["fk_target_field_id"]
 
-        body_field = {}
+        body_field: MutableMapping[str, Optional[Any]] = {}
 
         # Update if specified, otherwise reset one that had been set
         if api_field.get("display_name") != column_display_name and (
@@ -905,7 +906,11 @@ class MetabaseClient:
             headers["X-Metabase-Session"] = self.session_id
 
         response = requests.request(
-            method, f"{self.protocol}://{self.host}{path}", verify=self.verify, **kwargs
+            method,
+            f"{self.protocol}://{self.host}{path}",
+            verify=self.verify,
+            timeout=30,
+            **kwargs,
         )
 
         if critical:

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -253,8 +253,13 @@ class MetabaseClient:
         model_visibility = model.visibility_type or None
 
         body_table = {}
-        if api_table.get("display_name") != model_display_name:
+
+        # Update if specified, otherwise reset one that had been set
+        if api_table.get("display_name") != model_display_name and (
+            model_display_name or api_table.get("display_name") != api_table.get("name")
+        ):
             body_table["display_name"] = model_display_name
+
         if api_table.get("description") != model_description:
             body_table["description"] = model_description
         if api_table.get("points_of_interest") != model_points_of_interest:

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -389,12 +389,15 @@ class MetabaseClient:
         if api_field["fk_target_field_id"] and not fk_target_field_id:
             fk_target_field_id = api_field["fk_target_field_id"]
 
-        api_settings = api_field.get("settings") or {}
-        body_field = {
-            "settings": api_settings.copy(),
-        }
-        if api_field.get("display_name") != column_display_name:
+        body_field = {}
+
+        # Update if specified, otherwise reset one that had been set
+        if api_field.get("display_name") != column_display_name and (
+            column_display_name
+            or api_field.get("display_name") != api_field.get("name")
+        ):
             body_field["display_name"] = column_display_name
+
         if api_field.get("description") != column_description:
             body_field["description"] = column_description
         if api_field.get("visibility_type") != column_visibility:
@@ -411,11 +414,13 @@ class MetabaseClient:
             and column.coercion_strategy
         ):
             body_field["coercion_strategy"] = column.coercion_strategy
-        if (
-            api_settings.get("number_style") != column.number_style
-            and column.number_style
-        ):
-            body_field["settings"]["number_style"] = column.number_style
+
+        settings = api_field.get("settings") or {}
+        if settings.get("number_style") != column.number_style and column.number_style:
+            settings["number_style"] = column.number_style
+
+        if settings:
+            body_field["settings"] = settings
 
         # Allow explicit null type to override detected one
         if api_field.get(semantic_type_key) != column.semantic_type and (

--- a/dbtmetabase/models/metabase.py
+++ b/dbtmetabase/models/metabase.py
@@ -3,19 +3,21 @@ from enum import Enum
 from typing import MutableMapping, Optional, Sequence
 
 # Allowed metabase.* fields
-# Must be covered by MetabaseModel attributes
-METABASE_MODEL_META_FIELDS = [
+_METABASE_COMMON_META_FIELDS = [
     "display_name",
     "visibility_type",
-    "points_of_interest",
-    "caveats",
 ]
 # Must be covered by MetabaseColumn attributes
-METABASE_COLUMN_META_FIELDS = METABASE_MODEL_META_FIELDS + [
+METABASE_COLUMN_META_FIELDS = _METABASE_COMMON_META_FIELDS + [
     "semantic_type",
     "has_field_values",
     "coercion_strategy",
     "number_style",
+]
+# Must be covered by MetabaseModel attributes
+METABASE_MODEL_META_FIELDS = _METABASE_COMMON_META_FIELDS + [
+    "points_of_interest",
+    "caveats",
 ]
 
 # Default model schema (only schema in BigQuery)
@@ -31,12 +33,10 @@ class ModelType(str, Enum):
 class MetabaseColumn:
     name: str
     description: Optional[str] = None
+
     display_name: Optional[str] = None
-
-    meta_fields: MutableMapping = field(default_factory=dict)
-
-    semantic_type: Optional[str] = None
     visibility_type: Optional[str] = None
+    semantic_type: Optional[str] = None
     has_field_values: Optional[str] = None
     coercion_strategy: Optional[str] = None
     number_style: Optional[str] = None
@@ -44,13 +44,17 @@ class MetabaseColumn:
     fk_target_table: Optional[str] = None
     fk_target_field: Optional[str] = None
 
+    meta_fields: MutableMapping = field(default_factory=dict)
+
 
 @dataclass
 class MetabaseModel:
     name: str
     schema: str
     description: str = ""
+
     display_name: Optional[str] = None
+    visibility_type: Optional[str] = None
     points_of_interest: Optional[str] = None
     caveats: Optional[str] = None
 
@@ -58,8 +62,6 @@ class MetabaseModel:
     dbt_name: Optional[str] = None
     source: Optional[str] = None
     unique_id: Optional[str] = None
-
-    visibility_type: Optional[str] = None
 
     @property
     def ref(self) -> Optional[str]:


### PR DESCRIPTION
Incorrect default values were causing unnecessary API updates for all tables and fields:

- #111 caused null "display_name" updates where API defaults to same value as "name" on fields
- #112 propagated the same logic to tables
- #145 caused empty "settings" to be set to `{}` instead of null on fields

Also ignoring meta fields that don't apply to either tables or columns (e.g. caveats).