### PR TITLE
Improve Metabase display name handling

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -355,7 +355,11 @@ class MetabaseClient:
 
         # Empty strings not accepted by Metabase
         model_display_name = model.display_name or None
-        model_description = model.description or None
+        if not model.description:
+            model_description = None
+        else:
+            # We want to always convert newlines to spaces
+            model_description = model.description.replace("\n", " ")
         model_points_of_interest = model.points_of_interest or None
         model_caveats = model.caveats or None
         model_visibility = model.visibility_type or None

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -156,6 +156,7 @@ class DbtFolderReader(DbtReader):
 
         # Resolved name is what the name will be in the database
         resolved_name = model.get("alias", model.get("identifier"))
+        display_name = meta.get("metabase.display_name")
         dbt_name = None
         if not resolved_name:
             resolved_name = model["name"]
@@ -164,6 +165,7 @@ class DbtFolderReader(DbtReader):
 
         return MetabaseModel(
             name=resolved_name,
+            display_name=display_name,
             schema=schema,
             description=description,
             columns=metabase_columns,


### PR DESCRIPTION
A couple small tweaks that we found useful in https://github.com/cal-itp/data-infra/tree/main/warehouse. Open to suggestions; would it be useful to only strip the whitespace if configured?

Fix: Replaces newlines in descriptions before syncing; we have some large model-level documentation blocks and Metabase just strips out the newlines between paragraphs, leaving no whitespace between paragraphs.

Feature: Parses `metabase.display_name` from the meta dictionary to allow for overriding; we use prefixes that do not look good in direct title-case, and overriding via the YAML makes it easy to change.