### PR TITLE
feat: Add the 'cert' argument to the Requests framework

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -10,6 +10,7 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -120,6 +121,7 @@ class MetabaseClient:
         user: str,
         password: str,
         verify: Optional[Union[str, bool]] = None,
+        cert: Optional[Union[str, Tuple[str, str]]] = None,
         session_id: Optional[str] = None,
         use_http: bool = False,
         sync: Optional[bool] = True,
@@ -136,6 +138,7 @@ class MetabaseClient:
         Keyword Arguments:
             use_http {bool} -- Use HTTP instead of HTTPS. (default: {False})
             verify {Union[str, bool]} -- Path to certificate or disable verification. (default: {None})
+            cert {Union[str, Tuple[str, str]]} -- Path to a custom certificate to be used by the Metabase client. (default: {None})
             session_id {str} -- Metabase session ID. (default: {None})
             sync (bool, optional): Attempt to synchronize Metabase schema with local models. Defaults to True.
             sync_timeout (Optional[int], optional): Synchronization timeout (in secs). Defaults to None.
@@ -144,6 +147,7 @@ class MetabaseClient:
         self.base_url = f"{'http' if use_http else 'https'}://{host}"
         self.session = requests.Session()
         self.session.verify = verify
+        self.session.cert = cert
         adaptor = HTTPAdapter(max_retries=Retry(total=3, backoff_factor=0.5))
         self.session.mount(self.base_url, adaptor)
         session_header = session_id or self.get_session_id(user, password)

--- a/dbtmetabase/models/interface.py
+++ b/dbtmetabase/models/interface.py
@@ -24,6 +24,7 @@ class MetabaseInterface:
         session_id: Optional[str] = None,
         use_http: bool = False,
         verify: Optional[Union[str, bool]] = True,
+        cert: Optional[Union[str, Tuple[str, str]]] = None,
         sync: bool = True,
         sync_timeout: Optional[int] = None,
         exclude_sources: bool = False,
@@ -38,6 +39,7 @@ class MetabaseInterface:
             session_id (Optional[str], optional): Session ID. Defaults to None.
             use_http (bool, optional): Use HTTP to connect to Metabase.. Defaults to False.
             verify (Optional[Union[str, bool]], optional): Path to custom certificate bundle to be used by Metabase client. Defaults to True.
+            cert (Optional[Union[str, Tuple[str, str]]], optional): Path to a custom certificate to be used by the Metabase client, or a tuple containing the path to the certificate and key. Defaults to None.
             sync (bool, optional): Attempt to synchronize Metabase schema with local models. Defaults to True.
             sync_timeout (Optional[int], optional): Synchronization timeout (in secs). Defaults to None.
             exclude_sources (bool, optional): Exclude exporting sources. Defaults to False.
@@ -52,6 +54,7 @@ class MetabaseInterface:
         # Metabase additional connection opts
         self.use_http = use_http
         self.verify = verify
+        self.cert = cert
         # Metabase Sync
         self.sync = sync
         self.sync_timeout = sync_timeout
@@ -87,6 +90,7 @@ class MetabaseInterface:
             password=self.password,
             use_http=self.use_http,
             verify=self.verify,
+            cert=self.cert,
             session_id=self.session_id,
             sync=self.sync,
             sync_timeout=self.sync_timeout,


### PR DESCRIPTION
To access the Metabase database in my company, we need to present a certificate to prove our identity. 
To do this, we need to use the Requests argument: "cert"
So I add it in the MetabaseClient object 