### PR TITLE
Remove unused statement in metabase.py

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -226,7 +226,6 @@ class MetabaseClient:
         self.api("post", f"/api/database/{database_id}/sync_schema")
 
         deadline = int(time.time()) + timeout
-        sync_successful = False
         while True:
             self.metadata = self.build_metadata(database_id)
             sync_successful = self.models_compatible(models)


### PR DESCRIPTION
Hey, 

As discussed here #163 just a small cleaning by Pycharm. 
As `sync_successful` will always be changed line 232 `sync_successful = self.models_compatible(models)`  because the first iteration of the loop will always be executed the assignment to False is unused. 

