### PR TITLE
fixed exposure names and added labels

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -731,7 +731,7 @@ class MetabaseClient:
 
                 exposure_label = exposure_name
                 # Only letters, numbers, underscores and hyphens allowed in model names in dbt docs DAG / No duplicate model names
-                exposure_name = re.sub("[^\w-]", "_", exposure_name)
+                exposure_name = re.sub(r"[^\w-]", "_", exposure_name)
                 enumer = 1
                 while exposure_name in documented_exposure_names:
                     exposure_name = f"{exposure_name}_{enumer}"

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -730,8 +730,8 @@ class MetabaseClient:
                     creator_name = creator.get("common_name")
 
                 exposure_label = exposure_name
-                # Only lower case letters and underscores allowed in model names in dbt docs DAG / No duplicate model names
-                exposure_name = re.sub("[^a-z0-9]", "_", exposure_name.lower())
+                # Only letters, numbers, underscores and hyphens allowed in model names in dbt docs DAG / No duplicate model names
+                exposure_name = re.sub("[^\w-]", "_", exposure_name)
                 enumer = 1
                 while exposure_name in documented_exposure_names:
                     exposure_name = f"{exposure_name}_{enumer}"

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -729,8 +729,9 @@ class MetabaseClient:
                     creator_email = creator.get("email")
                     creator_name = creator.get("common_name")
 
-                # No spaces allowed in model names in dbt docs DAG / No duplicate model names
-                exposure_name = exposure_name.replace(" ", "_")
+                exposure_label = exposure_name
+                # Only lower case letters and underscores allowed in model names in dbt docs DAG / No duplicate model names
+                exposure_name = re.sub("[^a-z0-9]", "_", exposure_name.lower())
                 enumer = 1
                 while exposure_name in documented_exposure_names:
                     exposure_name = f"{exposure_name}_{enumer}"
@@ -742,6 +743,7 @@ class MetabaseClient:
                         exposure_type=exposure_type,
                         exposure_id=exposure_id,
                         name=exposure_name,
+                        label=exposure_label,
                         header=header,
                         created_at=exposure["created_at"],
                         creator_name=creator_name,
@@ -875,6 +877,7 @@ class MetabaseClient:
         exposure_type: str,
         exposure_id: int,
         name: str,
+        label: str,
         header: str,
         created_at: str,
         creator_name: str,
@@ -888,7 +891,8 @@ class MetabaseClient:
         Arguments:
             exposure_type {str} -- Model type in Metabase being either `card` or `dashboard`
             exposure_id {str} -- Card or Dashboard id in Metabase
-            name {str} -- Name of exposure as the title of the card or dashboard in Metabase
+            name {str} -- Name of exposure
+            label {str} -- Title of the card or dashboard in Metabase
             header {str} -- The header goes at the top of the description and is useful for prefixing metadata
             created_at {str} -- Timestamp of exposure creation derived from Metabase
             creator_name {str} -- Creator name derived from Metabase
@@ -938,6 +942,7 @@ class MetabaseClient:
 
         return {
             "name": name,
+            "label": label,
             "description": description,
             "type": "analysis" if exposure_type == "card" else "dashboard",
             "url": f"{self.base_url}/{exposure_type}/{exposure_id}",

--- a/tests/fixtures/exposure/baseline_test_exposures.yml
+++ b/tests/fixtures/exposure/baseline_test_exposures.yml
@@ -1,6 +1,8 @@
 version: 2
 exposures:
-- name: Customers,_Sum_of_Number_Of_Orders_and_Average_of_Number_Of_Orders,_Grouped_by_Most_Recent_Order_(day)
+- name: customers__sum_of_number_of_orders_and_average_of_number_of_orders__grouped_by_most_recent_order__day_
+  label: Customers, Sum of Number Of Orders and Average of Number Of Orders, Grouped
+    by Most Recent Order (day)
   description: '### Visualization: Line
 
 
@@ -22,7 +24,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Orders,_Count
+- name: orders__count
+  label: Orders, Count
   description: '### Visualization: Scalar
 
 
@@ -44,7 +47,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('orders')
-- name: A_look_at_your_customers_table
+- name: a_look_at_your_customers_table
+  label: A look at your customers table
   description: '### Dashboard Cards: 18
 
 
@@ -66,7 +70,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Customer_lifetime_value_over_time
+- name: customer_lifetime_value_over_time
+  label: Customer_lifetime_value over time
   description: '### Visualization: Line
 
 
@@ -88,7 +93,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Customer_lifetime_value_over_time_1
+- name: customer_lifetime_value_over_time_1
+  label: Customer_lifetime_value over time
   description: '### Visualization: Line
 
 
@@ -110,7 +116,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Customers_added_in_the_last_30_days
+- name: customers_added_in_the_last_30_days
+  label: Customers added in the last 30 days
   description: '### Visualization: Scalar
 
 
@@ -132,7 +139,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Customers_added_in_the_last_30_days_1
+- name: customers_added_in_the_last_30_days_1
+  label: Customers added in the last 30 days
   description: '### Visualization: Scalar
 
 
@@ -154,7 +162,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Customers_by_customer_lifetime_value
+- name: customers_by_customer_lifetime_value
+  label: Customers by customer_lifetime_value
   description: '### Visualization: Bar
 
 
@@ -176,7 +185,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Customers_by_number_of_orders
+- name: customers_by_number_of_orders
+  label: Customers by number_of_orders
   description: '### Visualization: Bar
 
 
@@ -198,7 +208,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Number_of_orders_over_time
+- name: number_of_orders_over_time
+  label: Number_of_orders over time
   description: '### Visualization: Line
 
 
@@ -220,7 +231,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Number_of_orders_over_time_1
+- name: number_of_orders_over_time_1
+  label: Number_of_orders over time
   description: '### Visualization: Line
 
 
@@ -242,7 +254,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Timestamp_by_day_of_the_week
+- name: timestamp_by_day_of_the_week
+  label: Timestamp by day of the week
   description: '### Visualization: Bar
 
 
@@ -264,7 +277,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Timestamp_by_day_of_the_week_1
+- name: timestamp_by_day_of_the_week_1
+  label: Timestamp by day of the week
   description: '### Visualization: Bar
 
 
@@ -286,7 +300,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Timestamp_by_month_of_the_year
+- name: timestamp_by_month_of_the_year
+  label: Timestamp by month of the year
   description: '### Visualization: Bar
 
 
@@ -308,7 +323,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Timestamp_by_month_of_the_year_1
+- name: timestamp_by_month_of_the_year_1
+  label: Timestamp by month of the year
   description: '### Visualization: Bar
 
 
@@ -330,7 +346,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Timestamp_by_quarter_of_the_year
+- name: timestamp_by_quarter_of_the_year
+  label: Timestamp by quarter of the year
   description: '### Visualization: Bar
 
 
@@ -352,7 +369,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Timestamp_by_quarter_of_the_year_1
+- name: timestamp_by_quarter_of_the_year_1
+  label: Timestamp by quarter of the year
   description: '### Visualization: Bar
 
 
@@ -374,7 +392,8 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: Total_customers
+- name: total_customers
+  label: Total customers
   description: '### Visualization: Scalar
 
 

--- a/tests/fixtures/exposure/baseline_test_exposures.yml
+++ b/tests/fixtures/exposure/baseline_test_exposures.yml
@@ -1,6 +1,6 @@
 version: 2
 exposures:
-- name: customers__sum_of_number_of_orders_and_average_of_number_of_orders__grouped_by_most_recent_order__day_
+- name: Customers__Sum_of_Number_Of_Orders_and_Average_of_Number_Of_Orders__Grouped_by_Most_Recent_Order__day_
   label: Customers, Sum of Number Of Orders and Average of Number Of Orders, Grouped
     by Most Recent Order (day)
   description: '### Visualization: Line
@@ -24,7 +24,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: orders__count
+- name: Orders__Count
   label: Orders, Count
   description: '### Visualization: Scalar
 
@@ -47,7 +47,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('orders')
-- name: a_look_at_your_customers_table
+- name: A_look_at_your_customers_table
   label: A look at your customers table
   description: '### Dashboard Cards: 18
 
@@ -70,7 +70,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: customer_lifetime_value_over_time
+- name: Customer_lifetime_value_over_time
   label: Customer_lifetime_value over time
   description: '### Visualization: Line
 
@@ -93,7 +93,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: customer_lifetime_value_over_time_1
+- name: Customer_lifetime_value_over_time_1
   label: Customer_lifetime_value over time
   description: '### Visualization: Line
 
@@ -116,7 +116,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: customers_added_in_the_last_30_days
+- name: Customers_added_in_the_last_30_days
   label: Customers added in the last 30 days
   description: '### Visualization: Scalar
 
@@ -139,7 +139,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: customers_added_in_the_last_30_days_1
+- name: Customers_added_in_the_last_30_days_1
   label: Customers added in the last 30 days
   description: '### Visualization: Scalar
 
@@ -162,7 +162,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: customers_by_customer_lifetime_value
+- name: Customers_by_customer_lifetime_value
   label: Customers by customer_lifetime_value
   description: '### Visualization: Bar
 
@@ -185,7 +185,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: customers_by_number_of_orders
+- name: Customers_by_number_of_orders
   label: Customers by number_of_orders
   description: '### Visualization: Bar
 
@@ -208,7 +208,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: number_of_orders_over_time
+- name: Number_of_orders_over_time
   label: Number_of_orders over time
   description: '### Visualization: Line
 
@@ -231,7 +231,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: number_of_orders_over_time_1
+- name: Number_of_orders_over_time_1
   label: Number_of_orders over time
   description: '### Visualization: Line
 
@@ -254,7 +254,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: timestamp_by_day_of_the_week
+- name: Timestamp_by_day_of_the_week
   label: Timestamp by day of the week
   description: '### Visualization: Bar
 
@@ -277,7 +277,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: timestamp_by_day_of_the_week_1
+- name: Timestamp_by_day_of_the_week_1
   label: Timestamp by day of the week
   description: '### Visualization: Bar
 
@@ -300,7 +300,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: timestamp_by_month_of_the_year
+- name: Timestamp_by_month_of_the_year
   label: Timestamp by month of the year
   description: '### Visualization: Bar
 
@@ -323,7 +323,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: timestamp_by_month_of_the_year_1
+- name: Timestamp_by_month_of_the_year_1
   label: Timestamp by month of the year
   description: '### Visualization: Bar
 
@@ -346,7 +346,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: timestamp_by_quarter_of_the_year
+- name: Timestamp_by_quarter_of_the_year
   label: Timestamp by quarter of the year
   description: '### Visualization: Bar
 
@@ -369,7 +369,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: timestamp_by_quarter_of_the_year_1
+- name: Timestamp_by_quarter_of_the_year_1
   label: Timestamp by quarter of the year
   description: '### Visualization: Bar
 
@@ -392,7 +392,7 @@ exposures:
     email: user@example.com
   depends_on:
   - ref('customers')
-- name: total_customers
+- name: Total_customers
   label: Total customers
   description: '### Visualization: Scalar
 


### PR DESCRIPTION
# Problem
https://github.com/gouline/dbt-metabase/issues/168 Since dbt 1.3 exposure names containing other characters than letters, numbers, underscores and hyphens are deprecated

# Changes
- Replaced all characters not being letters, numbers or hyphens by underscores in the exposure name
- Added the original card name as exposure label