### PR TITLE
Improvements

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -727,7 +727,7 @@ class MetabaseClient:
 
                 exposure_label = exposure_name
                 # Only letters, numbers, underscores and hyphens allowed in model names in dbt docs DAG / No duplicate model names
-                exposure_name = re.sub(r"[^\w-]", "_", exposure_name)
+                exposure_name = re.sub(r"[^\w-]", "_", exposure_name).lower()
                 enumer = 1
                 while exposure_name in documented_exposure_names:
                     exposure_name = f"{exposure_name}_{enumer}"
@@ -935,7 +935,7 @@ class MetabaseClient:
         # Output exposure
 
         return {
-            "name": name.lower(),
+            "name": name,
             "label": label,
             "description": description,
             "type": "analysis" if exposure_type == "card" else "dashboard",

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -726,7 +726,7 @@ class MetabaseClient:
                     creator_name = creator.get("common_name")
 
                 exposure_label = exposure_name
-                # Only letters, numbers, underscores and hyphens allowed in model names in dbt docs DAG / No duplicate model names
+                # Only letters, numbers, underscores are allowed in model names in dbt docs DAG / No duplicate model names
                 exposure_name = re.sub(r"[^\w]", "_", exposure_name).lower()
                 enumer = 1
                 while exposure_name in documented_exposure_names:

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -645,7 +645,6 @@ class MetabaseClient:
         parsed_exposures = []
 
         for collection in self.collections:
-
             # Exclude collections by name
             if collection["name"] in collection_excludes:
                 continue
@@ -657,7 +656,6 @@ class MetabaseClient:
             # Iter through collection
             logger().info(":sparkles: Exploring collection %s", collection["name"])
             for item in self.api("get", f"/api/collection/{collection['id']}/items"):
-
                 # Ensure collection item is of parsable type
                 exposure_type = item["model"]
                 exposure_id = item["id"]
@@ -678,7 +676,6 @@ class MetabaseClient:
 
                 # Process exposure
                 if exposure_type == "card":
-
                     # Build header for card and extract models to self.models_exposed
                     header = "### Visualization: {}\n\n".format(
                         exposure.get("display", "Unknown").title()
@@ -689,7 +686,6 @@ class MetabaseClient:
                     native_query = self.native_query
 
                 elif exposure_type == "dashboard":
-
                     # We expect this dict key in order to iter through questions
                     if "ordered_cards" not in exposure:
                         continue
@@ -824,7 +820,6 @@ class MetabaseClient:
 
             # Find models exposed through joins
             for query_join in query.get("query", {}).get("joins", []):
-
                 # Handle questions based on other question in virtual db
                 if str(query_join.get("source-table", "")).startswith("card__"):
                     self._extract_card_exposures(
@@ -853,7 +848,6 @@ class MetabaseClient:
 
             # Parse SQL for exposures through FROM or JOIN clauses
             for sql_ref in re.findall(self.exposure_parser, native_query):
-
                 # Grab just the table / model name
                 clean_exposure = sql_ref.split(".")[-1].strip('"').upper()
 
@@ -941,7 +935,7 @@ class MetabaseClient:
         # Output exposure
 
         return {
-            "name": name,
+            "name": name.lower(),
             "label": label,
             "description": description,
             "type": "analysis" if exposure_type == "card" else "dashboard",
@@ -951,11 +945,15 @@ class MetabaseClient:
                 "name": creator_name,
                 "email": creator_email or "",
             },
-            "depends_on": [
-                refable_models[exposure.upper()]
-                for exposure in list({m for m in self.models_exposed})
-                if exposure.upper() in refable_models
-            ],
+            "depends_on": list(
+                set(
+                    [
+                        refable_models[exposure.upper()]
+                        for exposure in list({m for m in self.models_exposed})
+                        if exposure.upper() in refable_models
+                    ]
+                )
+            ),
         }
 
     def api(

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -727,7 +727,7 @@ class MetabaseClient:
 
                 exposure_label = exposure_name
                 # Only letters, numbers, underscores and hyphens allowed in model names in dbt docs DAG / No duplicate model names
-                exposure_name = re.sub(r"[^\w-]", "_", exposure_name).lower()
+                exposure_name = re.sub(r"[^\w]", "_", exposure_name).lower()
                 enumer = 1
                 while exposure_name in documented_exposure_names:
                     exposure_name = f"{exposure_name}_{enumer}"

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -101,7 +101,7 @@ class DbtFolderReader(DbtReader):
             "source_name",
         ]
         try:
-            dbt_tables = (
+            dbt_table_json_lines = (
                 subprocess.run(
                     get_dbt_tables_cli_args,
                     cwd=self.path,
@@ -118,7 +118,7 @@ class DbtFolderReader(DbtReader):
             )
             raise e
         dbt_table_jsons = []
-        for dbt_table in dbt_tables:
+        for dbt_table in dbt_table_json_lines:
             try:
                 dbt_table_json = json.loads(dbt_table)
                 if type(dbt_table_json) == dict:

--- a/dbtmetabase/parsers/dbt_folder.py
+++ b/dbtmetabase/parsers/dbt_folder.py
@@ -40,7 +40,12 @@ class DbtFolderReader(DbtReader):
 
         schema = self.schema or METABASE_MODEL_DEFAULT_SCHEMA
 
-        for path in (Path(self.path) / "models").rglob("*.yml"):
+        models_dir_path = Path(self.path) / "models"
+        property_yaml_paths = [
+            *models_dir_path.rglob("*.yml"),
+            *models_dir_path.rglob("*.yaml"),
+        ]
+        for path in property_yaml_paths:
             with open(path, "r", encoding="utf-8") as stream:
                 schema_file = yaml.safe_load(stream)
                 if not schema_file:


### PR DESCRIPTION
1. The [first change](https://github.com/gouline/dbt-metabase/commit/2dbc756da67b9e64cc78070f81b04ec1b3d4a3a1) also searches for dbt property files in `models/*.yaml` and not only `models/*.yml`.
2. The [second change](https://github.com/gouline/dbt-metabase/commit/6b5246136a3a8cd22f443485bbb6c6476181e8de) corrects the format of exposures.
2.1 In dbt 1.3.0 onwards, you're not allowed to have upper-case characters in the exposure's name.
2.2 If a dashboard has two entities that query the same table, they'll be a duplicate in `depends_on`. I applied a dedup for that.
3. Listing dbt tables (models, sources) using `dbt ls`.
The main motivation for doing so is being able to safely get dbt models that are not defined in the property YAML files.
An alternative would've been to parse `models/*.sql` files but that's difficult due to the `alias` config that can override the table name from the default file name.
Using `dbt ls` allows us to safely get the table name.