### PR TITLE
Python 3.8 minimum

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7.16"
+          python-version: "3.8.18"
 
       - name: Requirements
         run: make requirements

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7.16"
+          python-version: "3.8.18"
 
       - uses: actions/cache@v2
         with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Metabase data model.
 
 ## Requirements
 
-Requires Python 3.7 or above.
+Requires Python 3.8 or above.
 
 ## Main Features
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,9 @@
 pip>=23.3.1
-setuptools>=68
-wheel
-pylint>=2.17.7
-mypy>=1.4.1
+setuptools>=69.0.2
+wheel>=0.42.0
+pylint>=3.0.2
+mypy>=1.7.1
 types-requests
 types-PyYAML
-black>=23.3.0
-isort>=5.11.5
+black>=23.11.0
+isort>=5.12.0

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 
 from setuptools import find_packages, setup
 
-if sys.version_info < (3, 7):
-    raise ValueError("Requires Python 3.7+")
+if sys.version_info < (3, 8):
+    raise ValueError("Requires Python 3.8+")
 
 
 def requires_from_file(filename: str) -> list:
@@ -39,7 +39,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
- Require Python 3.8 as the minimum version going forward
- Update build dependencies to newer versions supported for 3.8
- Revision of #192