### PR TITLE
Bring back _version.py file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import logging
 
 from .dbt import DbtReader
@@ -9,7 +8,9 @@ logger = logging.getLogger(__name__)
 __all__ = ["DbtReader", "MetabaseClient"]
 
 try:
-    __version__ = importlib.metadata.version("dbt-metabase")
-except importlib.metadata.PackageNotFoundError:
-    logger.warning("No version found in metadata")
-    __version__ = "0.0.0-UNKONWN"
+    from ._version import __version__ as version  # type: ignore
+
+    __version__ = version
+except ModuleNotFoundError:
+    logging.warning("No _version.py file")
+    __version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools>=60", "setuptools-scm"]
 
 [tool.setuptools_scm]
+version_file = "dbtmetabase/_version.py"
 
 [tool.black]
 include = '\.pyi?$'


### PR DESCRIPTION
This appears to be the current standard in the Python community.