### PR TITLE
Improvements to exposure extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,28 @@ dev-sandbox-models:
 		--metabase-database $$POSTGRES_DB )
 .PHONY: dev-sandbox-models
 
+dev-sandbox-exposures:
+	rm -rf tests/fixtures/sample_project/models/exposures
+	mkdir -p tests/fixtures/sample_project/models/exposures
+	( source sandbox/.env && python3 -m dbtmetabase exposures \
+		--dbt-manifest-path sandbox/target/manifest.json \
+		--dbt-database $$POSTGRES_DB \
+		--metabase-url http://localhost:$$MB_PORT \
+		--metabase-username $$MB_USER \
+		--metabase-password $$MB_PASSWORD \
+		--output-path tests/fixtures/sample_project/models/exposures \
+		--output-grouping collection )
+	
+	( source sandbox/.env && cd tests/fixtures/sample_project && \
+		POSTGRES_HOST=localhost \
+		POSTGRES_PORT=$$POSTGRES_PORT \
+		POSTGRES_USER=$$POSTGRES_USER \
+		POSTGRES_PASSWORD=$$POSTGRES_PASSWORD \
+		POSTGRES_DB=$$POSTGRES_DB \
+		POSTGRES_SCHEMA=$$POSTGRES_SCHEMA \
+		dbt docs generate --profiles-dir ../../../sandbox )
+.PHONY: dev-sandbox-exposures
+
 dev-sandbox-down:
 	( cd sandbox && docker-compose down )
 .PHONY: dev-sandbox-up

--- a/dbtmetabase/__main__.py
+++ b/dbtmetabase/__main__.py
@@ -340,17 +340,14 @@ def models(
     type=click.Path(exists=True, file_okay=False),
     default=".",
     show_default=True,
-    help="Output path for generated exposure YAML.",
+    help="Output path for generated exposure YAML files.",
 )
 @click.option(
-    "--output-name",
-    metavar="NAME",
-    envvar="OUTPUT_NAME",
+    "--output-grouping",
+    envvar="OUTPUT_GROUPING",
     show_envvar=True,
-    type=click.STRING,
-    default="metabase_exposures.yml",
-    show_default=True,
-    help="File name for generated exposure YAML.",
+    type=click.Choice(["collection", "type"]),
+    help="Grouping for output YAML files",
 )
 @click.option(
     "--metabase-include-personal-collections",
@@ -358,6 +355,15 @@ def models(
     show_envvar=True,
     is_flag=True,
     help="Include personal collections when parsing exposures.",
+)
+@click.option(
+    "--metabase-collection-includes",
+    metavar="COLLECTIONS",
+    envvar="METABASE_COLLECTION_INCLUDES",
+    show_envvar=True,
+    type=click.UNPROCESSED,
+    callback=_comma_separated_list_callback,
+    help="Metabase collection names to includes.",
 )
 @click.option(
     "--metabase-collection-excludes",
@@ -370,8 +376,9 @@ def models(
 )
 def exposures(
     output_path: str,
-    output_name: str,
+    output_grouping: Optional[str],
     metabase_include_personal_collections: bool,
+    metabase_collection_includes: Optional[Iterable],
     metabase_collection_excludes: Optional[Iterable],
     dbt_reader: DbtReader,
     metabase_client: MetabaseClient,
@@ -380,8 +387,9 @@ def exposures(
     metabase_client.extract_exposures(
         models=dbt_models,
         output_path=output_path,
-        output_name=output_name,
+        output_grouping=output_grouping,
         include_personal_collections=metabase_include_personal_collections,
+        collection_includes=metabase_collection_includes,
         collection_excludes=metabase_collection_excludes,
     )
 

--- a/dbtmetabase/_format.py
+++ b/dbtmetabase/_format.py
@@ -1,0 +1,28 @@
+import re
+from typing import Optional
+
+
+def safe_name(text: Optional[str]) -> str:
+    """Sanitizes a human-readable "friendly" name to a safe string.
+
+    For example, "Joe's Collection" becomes "joe_s_collection".
+
+    Args:
+        text (Optional[str]): Unsafe text with non-underscore symbols and spaces.
+
+    Returns:
+        str: Sanitized lowercase string with underscores.
+    """
+    return re.sub(r"[^\w]", "_", text or "").lower()
+
+
+def safe_description(text: Optional[str]) -> str:
+    """Sanitizes a human-readable long text, such as description.
+
+    Args:
+        text (Optional[str]): Unsafe long text with Jinja syntax.
+
+    Returns:
+        str: Sanitized string with escaped Jinja syntax.
+    """
+    return re.sub(r"{{(.*)}}", r"\1", text or "")

--- a/tests/fixtures/exposure/.gitignore
+++ b/tests/fixtures/exposure/.gitignore
@@ -1,1 +1,1 @@
-unittest_exposures.yml
+exposures.yml

--- a/tests/test_metabase.py
+++ b/tests/test_metabase.py
@@ -269,20 +269,20 @@ class TestMetabaseClient(unittest.TestCase):
 
     def test_exposures(self):
         output_path = FIXTURES_PATH / "exposure"
-        output_name = "unittest_exposures"
         job = _ExtractExposuresJob(
             client=self.client,
             models=MODELS,
             output_path=str(output_path),
-            output_name=output_name,
+            output_grouping=None,
             include_personal_collections=False,
+            collection_includes=None,
             collection_excludes=None,
         )
         job.execute()
 
         with open(output_path / "baseline_test_exposures.yml", encoding="utf-8") as f:
             expected = yaml.safe_load(f)
-        with open(output_path / f"{output_name}.yml", encoding="utf-8") as f:
+        with open(output_path / "exposures.yml", encoding="utf-8") as f:
             actual = yaml.safe_load(f)
 
         expected_exposures = sorted(expected["exposures"], key=itemgetter("name"))


### PR DESCRIPTION
Multiple requested improvements to exposure extraction:

- Optional grouping by type (e.g. question/123.yml) or collection (e.g. our_analytics.yml)
  - Resolves #102
- Sanitize exposure descriptions to replace `{{foo}}` with `foo`
  - Resolves #148
- Sort exposures by name within each YAML file
  - Resolves #165
- Add inclusion collection name filtering (in addition to existing exclusion filtering)
  - Resolves #201