### PR TITLE
Fix list index out of range in manifest reader

### DIFF
--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -182,8 +182,7 @@ class Manifest:
 
                 # Skip the incoming relationship tests, in which the fk_target_table is the model currently being read.
                 # Otherwise, the primary key of the current model would be (incorrectly) determined to be FK.
-                is_incoming_relationship_test = depends_on_nodes[1] != unique_id
-                if len(depends_on_nodes) == 2 and is_incoming_relationship_test:
+                if len(depends_on_nodes) == 2 and depends_on_nodes[1] != unique_id:
                     _logger.debug(
                         "Skip this incoming relationship test, concerning nodes %s",
                         depends_on_nodes,


### PR DESCRIPTION
- Fix for a "list index out of range" error in manifest reader
- Caused by using index 1 item in the list first and checking whether it's long enough second #158