### PR TITLE
Fix list index out of range in manifest reader in 0.10

### DIFF
--- a/dbtmetabase/parsers/dbt_manifest.py
+++ b/dbtmetabase/parsers/dbt_manifest.py
@@ -204,8 +204,7 @@ class DbtManifestReader(DbtReader):
 
                 # Skip the incoming relationship tests, in which the fk_target_table is the model currently being read.
                 # Otherwise, the primary key of the current model would be (incorrectly) determined to be a foreign key.
-                is_incoming_relationship_test = depends_on_nodes[1] != unique_id
-                if len(depends_on_nodes) == 2 and is_incoming_relationship_test:
+                if len(depends_on_nodes) == 2 and depends_on_nodes[1] != unique_id:
                     logger().debug(
                         "Skip this incoming relationship test, concerning nodes %s.",
                         depends_on_nodes,


### PR DESCRIPTION
- Backport #210 to 0.10 release