### PR TITLE
Remove duplicate steps from master workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,21 +24,6 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Formatting check (black)
-        run: make check-fmt
-
-      - name: Imports ordering check (isort)
-        run: make check-imports
-
-      - name: Lint Python check (pylint)
-        run: make check-lint-python
-
-      - name: Type check (mypy)
-        run: make check-type
-
-      - name: Test
-        run: make test
-
       - name: Publish a Python distribution to PyPI
         if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Only run tests in pull requests where they can be fixed.