### PR TITLE
Filter precaution, API update log statements and common configs

### DIFF
--- a/dbtmetabase/__main__.py
+++ b/dbtmetabase/__main__.py
@@ -67,8 +67,12 @@ def cli(ctx: click.Context, config_path: str):
     if config_path_expanded.exists():
         with open(config_path_expanded, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f).get("config", {})
-            # Propagate root configs to all commands
-            ctx.default_map = {command: config for command in group.commands}
+            # Propagate common configs to all commands
+            common = {k: v for k, v in config.items() if k not in group.commands}
+            ctx.default_map = {
+                command: {**common, **config.get(command, {})}
+                for command in group.commands
+            }
 
 
 def _add_setup(func: Callable) -> Callable:

--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -319,7 +319,7 @@ class ModelsMixin(metaclass=ABCMeta):
         ):
             body_field[semantic_type_key] = column.semantic_type or None
 
-        update_name = f"{model_name}.{column_name}"
+        update_name = f"{schema_name}.{model_name}.{column_name}"
         if body_field:
             ctx.update(entity=api_field, change=body_field, name=update_name)
             _logger.info(

--- a/dbtmetabase/format.py
+++ b/dbtmetabase/format.py
@@ -24,17 +24,23 @@ class Filter:
             include (Optional[Sequence[str]], optional): Optional inclusions (i.e. include only these). Defaults to None.
             exclude (Optional[Sequence[str]], optional): Optional exclusion list (i.e. exclude these, even if in inclusion list). Defaults to None.
         """
-        self.include = [self._norm(x) for x in include or []]
-        self.exclude = [self._norm(x) for x in exclude or []]
+        self.include = self._norm_arg(include)
+        self.exclude = self._norm_arg(exclude)
 
     def match(self, item: str) -> bool:
-        item = self._norm(item)
+        item = self._norm_item(item)
         included = not self.include or item in self.include
         excluded = self.exclude and item in self.exclude
         return included and not excluded
 
     @staticmethod
-    def _norm(x: str) -> str:
+    def _norm_arg(arg: Optional[Sequence[str]]) -> Sequence[str]:
+        if isinstance(arg, str):
+            arg = [arg]
+        return [Filter._norm_item(x) for x in arg or []]
+
+    @staticmethod
+    def _norm_item(x: str) -> str:
         return x.upper()
 
 

--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -184,8 +184,9 @@ class Manifest:
                 # Otherwise, the primary key of the current model would be (incorrectly) determined to be FK.
                 if len(depends_on_nodes) == 2 and depends_on_nodes[1] != unique_id:
                     _logger.debug(
-                        "Circular dependency in '%s', skipping relationship",
-                        depends_on_nodes,
+                        "Circular dependency '%s' for '%s', skipping relationship",
+                        depends_on_nodes[1],
+                        unique_id,
                     )
                     continue
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -24,6 +24,8 @@ class TestFormat(unittest.TestCase):
                 exclude=("alpha",),
             ).match("Alpha")
         )
+        self.assertTrue(Filter(include="alpha").match("Alpha"))
+        self.assertFalse(Filter(exclude="alpha").match("Alpha"))
 
     def test_null_value(self):
         self.assertIsNotNone(NullValue)


### PR DESCRIPTION
- Filter expects a list or tuple, but if passed a string accidentally, it should still work
- Add full identifiers to API update log statements
- Propagate common values from config YAML to each command without overwriting