### PR TITLE
fix exposures crashing with referencing questions with multiple variables

### DIFF
--- a/dbtmetabase/format.py
+++ b/dbtmetabase/format.py
@@ -142,4 +142,4 @@ def safe_description(text: Optional[str]) -> str:
     Returns:
         str: Sanitized string with escaped Jinja syntax.
     """
-    return re.sub(r"{{(.*)}}", r"(\1)", text or "")
+    return re.sub(r"{{(.*?)}}", r"(\1)", text or "")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -56,6 +56,10 @@ class TestFormat(unittest.TestCase):
             "Depends on\n\nQuestion { #2 }!",
             safe_description("Depends on\n\nQuestion { #2 }!"),
         )
+        self.assertEqual(
+            "(start_date) - cast((rolling_days))",
+            safe_description("{{start_date}} - cast({{rolling_days}})"),
+        )
 
     def test_dump_yaml(self):
         path = Path("tests") / "tmp" / "test_dump_yaml.yml"


### PR DESCRIPTION
**Problem**
Running `dbt-metabase exposures` produces faulty `exposures.json` if the referenced Metabase questions contain multiple variables in one query.

**To reproduce**
The problem is due to the greedy nature of the `.*` regex pattern that will catch multiple sets of double braces if they exist within the same line.

_Example query:_
```
SELECT *
FROM generate_series(  DATE_TRUNC ('day',{{start_date}}  - cast({{rolling_days}} || ' days' as interval)),  DATE_TRUNC ('day',now() - interval '1 day'), '1 day') as buckets(day);
```

**Solution**
Make the regex less greedy to match as little text as possible.
