### PR TITLE
Fix exposures depends_on refs with aliased models

### DIFF
--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -82,7 +82,7 @@ class ModelsMixin(metaclass=ABCMeta):
             synced = True
             for model in models:
                 schema_name = model.schema.upper()
-                model_name = model.name.upper()
+                model_name = model.alias.upper()
                 table_key = f"{schema_name}.{model_name}"
 
                 table = tables.get(table_key)
@@ -149,7 +149,7 @@ class ModelsMixin(metaclass=ABCMeta):
         success = True
 
         schema_name = model.schema.upper()
-        model_name = model.name.upper()
+        model_name = model.alias.upper()
         table_key = f"{schema_name}.{model_name}"
 
         api_table = ctx.tables.get(table_key)

--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -110,7 +110,8 @@ class Manifest:
             database=database,
             schema=schema,
             group=group,
-            name=manifest_model.get(
+            name=manifest_model["name"],
+            alias=manifest_model.get(
                 "alias", manifest_model.get("identifier", manifest_model["name"])
             ),
             description=manifest_model.get("description"),
@@ -343,6 +344,7 @@ class Model:
     group: Group
 
     name: str
+    alias: str
     description: Optional[str] = None
     display_name: Optional[str] = None
     visibility_type: Optional[str] = None

--- a/tests/_mocks.py
+++ b/tests/_mocks.py
@@ -1,9 +1,9 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 from dbtmetabase.core import DbtMetabase
-from dbtmetabase.manifest import Manifest
+from dbtmetabase.manifest import Manifest, Model
 from dbtmetabase.metabase import Metabase
 
 FIXTURES_PATH = Path("tests") / "fixtures"
@@ -40,11 +40,20 @@ class MockMetabase(Metabase):
         return {}
 
 
+class MockManifest(Manifest):
+    _models: Sequence[Model] = []
+
+    def read_models(self) -> Sequence[Model]:
+        if not self._models:
+            self._models = super().read_models()
+        return self._models
+
+
 class MockDbtMetabase(DbtMetabase):
     def __init__(
         self,
         manifest_path: Path = FIXTURES_PATH / "manifest-v2.json",
         metabase_url: str = "http://localhost:3000",
     ):  # pylint: disable=super-init-not-called
-        self._manifest = Manifest(path=manifest_path)
+        self._manifest = MockManifest(path=manifest_path)
         self._metabase = MockMetabase(url=metabase_url)

--- a/tests/test_exposures.py
+++ b/tests/test_exposures.py
@@ -72,3 +72,24 @@ class TestExposures(unittest.TestCase):
                 fixtures_path / "dashboard" / f"{i}.yml",
                 output_path / "dashboard" / f"{i}.yml",
             )
+
+    def test_exposures_aliased_ref(self):
+        for model in self.c._manifest.read_models():  # pylint: disable=protected-access
+            if not model.name.startswith("stg_"):
+                model.alias = f"{model.name}_alias"
+
+        aliases = [m.alias for m in self.c.manifest.read_models()]
+        self.assertIn("orders_alias", aliases)
+        self.assertIn("customers_alias", aliases)
+
+        fixtures_path = FIXTURES_PATH / "exposure" / "default"
+        output_path = TMP_PATH / "exposure" / "aliased"
+        self.c.extract_exposures(
+            output_path=str(output_path),
+            output_grouping=None,
+        )
+
+        self._assert_exposures(
+            fixtures_path / "exposures.yml",
+            output_path / "exposures.yml",
+        )

--- a/tests/test_exposures.py
+++ b/tests/test_exposures.py
@@ -74,7 +74,7 @@ class TestExposures(unittest.TestCase):
             )
 
     def test_exposures_aliased_ref(self):
-        for model in self.c._manifest.read_models():  # pylint: disable=protected-access
+        for model in self.c.manifest.read_models():
             if not model.name.startswith("stg_"):
                 model.alias = f"{model.name}_alias"
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -28,6 +28,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="customers",
+                    alias="customers",
                     description="This table has basic information about a customer, as well as some derived facts based on a customer's orders",
                     display_name="clients",
                     unique_id="model.sandbox.customers",
@@ -68,6 +69,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="orders",
+                    alias="orders",
                     description="This table has basic information about orders, as well as some derived facts based on payments",
                     points_of_interest="Basic information only",
                     caveats="Some facts are derived from payments",
@@ -119,6 +121,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="stg_customers",
+                    alias="stg_customers",
                     description="",
                     unique_id="model.sandbox.stg_customers",
                     columns=[
@@ -133,6 +136,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="stg_payments",
+                    alias="stg_payments",
                     description="",
                     unique_id="model.sandbox.stg_payments",
                     columns=[
@@ -151,6 +155,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="stg_orders",
+                    alias="stg_orders",
                     description="",
                     unique_id="model.sandbox.stg_orders",
                     columns=[
@@ -177,6 +182,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="orders",
+                    alias="orders",
                     description="This table has basic information about orders, as well as some derived facts based on payments",
                     unique_id="model.jaffle_shop.orders",
                     columns=[
@@ -226,6 +232,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="customers",
+                    alias="customers",
                     description="This table has basic information about a customer, as well as some derived facts based on a customer's orders",
                     unique_id="model.jaffle_shop.customers",
                     columns=[
@@ -265,6 +272,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="stg_orders",
+                    alias="stg_orders",
                     description="",
                     unique_id="model.jaffle_shop.stg_orders",
                     columns=[
@@ -283,6 +291,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="stg_payments",
+                    alias="stg_payments",
                     description="",
                     unique_id="model.jaffle_shop.stg_payments",
                     columns=[
@@ -301,6 +310,7 @@ class TestManifest(unittest.TestCase):
                     schema="public",
                     group=Group.nodes,
                     name="stg_customers",
+                    alias="stg_customers",
                     description="",
                     unique_id="model.jaffle_shop.stg_customers",
                     tags=[],

--- a/tests/test_metabase.py
+++ b/tests/test_metabase.py
@@ -1,7 +1,5 @@
 import unittest
 
-from dbtmetabase.metabase import Metabase
-
 from ._mocks import MockMetabase
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,3 @@
-# pylint: disable=protected-access,no-member
-
 import unittest
 
 from ._mocks import MockDbtMetabase
@@ -7,6 +5,7 @@ from ._mocks import MockDbtMetabase
 
 class TestModels(unittest.TestCase):
     def setUp(self):
+        # pylint: disable=protected-access
         self.c = MockDbtMetabase()
         self.c._ModelsMixin__SYNC_PERIOD = 1  # type: ignore
 
@@ -18,6 +17,7 @@ class TestModels(unittest.TestCase):
         )
 
     def test_build_lookups(self):
+        # pylint: disable=protected-access,no-member
         expected_tables = [
             "PUBLIC.CUSTOMERS",
             "PUBLIC.ORDERS",


### PR DESCRIPTION
- Separate model alias from name in manifest
- Use name for dependency parsing in exposures and convert to sets to remove duplicates
- Fixes #178