### PR TITLE
Support primary key and foreign key column constraints

### DIFF
--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses as dc
 import json
 import logging
+import re
 from enum import Enum
 from pathlib import Path
 from typing import (
@@ -41,6 +42,9 @@ _MODEL_META_FIELDS = _COMMON_META_FIELDS + [
 
 # Default model schema (only schema in BigQuery)
 DEFAULT_SCHEMA = "PUBLIC"
+
+# Foreign key constraint: "schema.model (column)" / "model (column)"
+_CONSTRAINT_FK_PARSER = re.compile(r"(?P<model>.+)\s+\((?P<column>.+)\)")
 
 
 class Manifest:
@@ -142,12 +146,11 @@ class Manifest:
             ),
         )
 
-        self._set_column_fk(
+        self._set_column_relationship(
             manifest_column=manifest_column,
             column=column,
-            table=relationship["fk_target_table"] if relationship else None,
-            field=relationship["fk_target_field"] if relationship else None,
             schema=schema,
+            relationship=relationship,
         )
 
         return column
@@ -250,43 +253,62 @@ class Manifest:
 
         return relationships
 
-    def _set_column_fk(
+    def _set_column_relationship(
         self,
         manifest_column: Mapping,
         column: Column,
-        table: Optional[str],
-        field: Optional[str],
-        schema: Optional[str],
+        schema: str,
+        relationship: Optional[Mapping],
     ):
-        """Sets foreign key target on a column.
+        """Sets primary key and foreign key target on a column from constraints, meta fields or provided test relationship."""
 
-        Args:
-            manifest_column (Mapping): Schema column definition.
-            column (Column): Metabase column definition.
-            table (str): Foreign key target table.
-            field (str): Foreign key target field.
-            schema (str): Current schema name.
-        """
-        # Meta fields take precedence
+        fk_target_table = ""
+        fk_target_field = ""
+
+        # Precedence 1: Relationship test
+        if relationship:
+            fk_target_table = relationship["fk_target_table"]
+            fk_target_field = relationship["fk_target_field"]
+
+        # Precedence 2: Constraints
+        for constraint in manifest_column.get("constraints", []):
+            if constraint["type"] == "primary_key":
+                if not column.semantic_type:
+                    column.semantic_type = "type/PK"
+
+            elif constraint["type"] == "foreign_key":
+                constraint_expr = constraint.get("expression", "")
+                constraint_fk = _CONSTRAINT_FK_PARSER.search(constraint_expr)
+                if constraint_fk:
+                    fk_target_table = constraint_fk.group("model")
+                    fk_target_field = constraint_fk.group("column")
+                else:
+                    _logger.warning(
+                        "Unparsable '%s' foreign key constraint: %s",
+                        column.name,
+                        constraint_expr,
+                    )
+
+        # Precedence 3: Meta fields
         meta = manifest_column.get("meta", {})
-        table = meta.get(f"{_META_NS}.fk_target_table", table)
-        field = meta.get(f"{_META_NS}.fk_target_field", field)
+        fk_target_table = meta.get(f"{_META_NS}.fk_target_table", fk_target_table)
+        fk_target_field = meta.get(f"{_META_NS}.fk_target_field", fk_target_field)
 
-        if not table or not field:
-            if table or field:
+        if not fk_target_table or not fk_target_field:
+            if fk_target_table or fk_target_table:
                 _logger.warning(
                     "Foreign key requires table and field for column '%s'",
                     column.name,
                 )
             return
 
-        table_path = table.split(".")
-        if len(table_path) == 1 and schema:
-            table_path.insert(0, schema)
+        fk_target_table_path = fk_target_table.split(".")
+        if len(fk_target_table_path) == 1 and schema:
+            fk_target_table_path.insert(0, schema)
 
         column.semantic_type = "type/FK"
-        column.fk_target_table = ".".join([x.strip('"') for x in table_path])
-        column.fk_target_field = field.strip('"')
+        column.fk_target_table = ".".join([x.strip('"') for x in fk_target_table_path])
+        column.fk_target_field = fk_target_field.strip('"')
         _logger.debug(
             "Relation from '%s' to '%s.%s'",
             column.name,

--- a/sandbox/models/schema.yml
+++ b/sandbox/models/schema.yml
@@ -42,6 +42,8 @@ models:
 
     columns:
       - name: order_id
+        constraints:
+          - type: primary_key
         tests:
           - unique
           - not_null
@@ -49,11 +51,11 @@ models:
 
       - name: customer_id
         description: Foreign key to the customers table
+        constraints:
+          - type: foreign_key
+            expression: customers (customer_id)
         tests:
           - not_null
-          - relationships:
-              to: ref('customers')
-              field: customer_id
 
       - name: order_date
         description: Date (UTC) that the order was placed

--- a/tests/fixtures/manifest-v11.json
+++ b/tests/fixtures/manifest-v11.json
@@ -1,9 +1,9 @@
 {
     "metadata": {
         "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-        "dbt_version": "1.7.5",
-        "generated_at": "2024-01-25T01:54:22.285700Z",
-        "invocation_id": "2a379e22-b3cb-4596-8663-17abbbc84330",
+        "dbt_version": "1.7.8",
+        "generated_at": "2024-02-20T01:11:30.963279Z",
+        "invocation_id": "e0c2a315-8369-44bf-8cad-a6cbb98ce697",
         "env": {},
         "project_name": "sandbox",
         "project_id": "93bc63e0b4f48fbbff568d9fc0dc3def",
@@ -150,7 +150,7 @@
                     "metabase.display_name": "clients"
                 }
             },
-            "created_at": 1706145555.0016356,
+            "created_at": 1708330299.0858583,
             "relation_name": "\"dbtmetabase\".\"public\".\"customers\"",
             "raw_code": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final",
             "language": "sql",
@@ -197,23 +197,23 @@
             "latest_version": null,
             "deprecation_date": null
         },
-        "model.sandbox.orders": {
+        "seed.sandbox.raw_customers": {
             "database": "dbtmetabase",
             "schema": "public",
-            "name": "orders",
-            "resource_type": "model",
+            "name": "raw_customers",
+            "resource_type": "seed",
             "package_name": "sandbox",
-            "path": "orders.sql",
-            "original_file_path": "models/orders.sql",
-            "unique_id": "model.sandbox.orders",
+            "path": "raw_customers.csv",
+            "original_file_path": "seeds/raw_customers.csv",
+            "unique_id": "seed.sandbox.raw_customers",
             "fqn": [
                 "sandbox",
-                "orders"
+                "raw_customers"
             ],
-            "alias": "orders",
+            "alias": "raw_customers",
             "checksum": {
                 "name": "sha256",
-                "checksum": "9a13423dec138c8cedf1eb7e03f4ad86be3b378ef088ac9ecc09328b76d8986e"
+                "checksum": "357d173dda65a741ad97d6683502286cc2655bb396ab5f4dfad12b8c39bd2a63"
             },
             "config": {
                 "enabled": true,
@@ -221,12 +221,9 @@
                 "schema": null,
                 "database": null,
                 "tags": [],
-                "meta": {
-                    "metabase.points_of_interest": "Basic information only",
-                    "metabase.caveats": "Some facts are derived from payments"
-                },
+                "meta": {},
                 "group": null,
-                "materialized": "table",
+                "materialized": "seed",
                 "incremental_strategy": null,
                 "persist_docs": {},
                 "post-hook": [],
@@ -247,124 +244,236 @@
                     "enforced": false,
                     "alias_types": true
                 },
-                "access": "protected"
+                "delimiter": ",",
+                "quote_columns": null
             },
             "tags": [],
-            "description": "This table has basic information about orders, as well as some derived facts based on payments",
-            "columns": {
-                "order_id": {
-                    "name": "order_id",
-                    "description": "This is a unique identifier for an order",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "customer_id": {
-                    "name": "customer_id",
-                    "description": "Foreign key to the customers table",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "order_date": {
-                    "name": "order_date",
-                    "description": "Date (UTC) that the order was placed",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "status": {
-                    "name": "status",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "amount": {
-                    "name": "amount",
-                    "description": "Total amount (AUD) of the order",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "credit_card_amount": {
-                    "name": "credit_card_amount",
-                    "description": "Amount of the order (AUD) paid for by credit card",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "coupon_amount": {
-                    "name": "coupon_amount",
-                    "description": "Amount of the order (AUD) paid for by coupon",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "bank_transfer_amount": {
-                    "name": "bank_transfer_amount",
-                    "description": "Amount of the order (AUD) paid for by bank transfer",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "gift_card_amount": {
-                    "name": "gift_card_amount",
-                    "description": "Amount of the order (AUD) paid for by gift card",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {
-                "metabase.points_of_interest": "Basic information only",
-                "metabase.caveats": "Some facts are derived from payments"
-            },
+            "description": "",
+            "columns": {},
+            "meta": {},
             "group": null,
             "docs": {
                 "show": true,
                 "node_color": null
             },
-            "patch_path": "sandbox://models/schema.yml",
-            "build_path": "target/run/sandbox/models/orders.sql",
+            "patch_path": null,
+            "build_path": null,
             "deferred": false,
-            "unrendered_config": {
-                "materialized": "table",
-                "meta": {
-                    "metabase.points_of_interest": "Basic information only",
-                    "metabase.caveats": "Some facts are derived from payments"
-                }
+            "unrendered_config": {},
+            "created_at": 1708330299.0421724,
+            "relation_name": "\"dbtmetabase\".\"public\".\"raw_customers\"",
+            "raw_code": "",
+            "root_path": "/app/sandbox",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "seed.sandbox.raw_orders": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "raw_orders",
+            "resource_type": "seed",
+            "package_name": "sandbox",
+            "path": "raw_orders.csv",
+            "original_file_path": "seeds/raw_orders.csv",
+            "unique_id": "seed.sandbox.raw_orders",
+            "fqn": [
+                "sandbox",
+                "raw_orders"
+            ],
+            "alias": "raw_orders",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "6228dde8e17b9621f35c13e272ec67d3ff55b55499433f47d303adf2be72c17f"
             },
-            "created_at": 1706145555.0041838,
-            "relation_name": "\"dbtmetabase\".\"public\".\"orders\"",
-            "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708330299.0437803,
+            "relation_name": "\"dbtmetabase\".\"public\".\"raw_orders\"",
+            "raw_code": "",
+            "root_path": "/app/sandbox",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "seed.sandbox.raw_payments": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "raw_payments",
+            "resource_type": "seed",
+            "package_name": "sandbox",
+            "path": "raw_payments.csv",
+            "original_file_path": "seeds/raw_payments.csv",
+            "unique_id": "seed.sandbox.raw_payments",
+            "fqn": [
+                "sandbox",
+                "raw_payments"
+            ],
+            "alias": "raw_payments",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "6de0626a8db9c1750eefd1b2e17fac4c2a4b9f778eb50532d8b377b90de395e6"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708330299.045119,
+            "relation_name": "\"dbtmetabase\".\"public\".\"raw_payments\"",
+            "raw_code": "",
+            "root_path": "/app/sandbox",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": {
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "unique_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "unique_customers_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.unique_customers_customer_id.c5af1ff4b1",
+            "fqn": [
+                "sandbox",
+                "unique_customers_customer_id"
+            ],
+            "alias": "unique_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708330299.1369452,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
             "refs": [
                 {
-                    "name": "stg_orders",
-                    "package": null,
-                    "version": null
-                },
-                {
-                    "name": "stg_payments",
+                    "name": "customers",
                     "package": null,
                     "version": null
                 }
@@ -372,27 +481,110 @@
             "sources": [],
             "metrics": [],
             "depends_on": {
-                "macros": [],
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
                 "nodes": [
-                    "model.sandbox.stg_orders",
-                    "model.sandbox.stg_payments"
+                    "model.sandbox.customers"
                 ]
             },
-            "compiled_path": "target/compiled/sandbox/models/orders.sql",
-            "compiled": true,
-            "compiled_code": "\n\nwith orders as (\n\n    select * from \"dbtmetabase\".\"public\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"dbtmetabase\".\"public\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
+            "compiled_path": null,
             "contract": {
                 "enforced": false,
                 "alias_types": true,
                 "checksum": null
             },
-            "access": "protected",
-            "constraints": [],
-            "version": null,
-            "latest_version": null,
-            "deprecation_date": null
+            "column_name": "customer_id",
+            "file_key_name": "models.customers",
+            "attached_node": "model.sandbox.customers"
+        },
+        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": {
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_customers_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_customers_customer_id.5c9bf9911d",
+            "fqn": [
+                "sandbox",
+                "not_null_customers_customer_id"
+            ],
+            "alias": "not_null_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708330299.1383352,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.customers",
+            "attached_node": "model.sandbox.customers"
         },
         "model.sandbox.stg_customers": {
             "database": "dbtmetabase",
@@ -455,6 +647,24 @@
                     "constraints": [],
                     "quote": null,
                     "tags": []
+                },
+                "first_name": {
+                    "name": "first_name",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "last_name": {
+                    "name": "last_name",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
                 }
             },
             "meta": {},
@@ -469,7 +679,7 @@
             "unrendered_config": {
                 "materialized": "view"
             },
-            "created_at": 1706145555.0613995,
+            "created_at": 1708338357.5425656,
             "relation_name": "\"dbtmetabase\".\"public\".\"stg_customers\"",
             "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
             "language": "sql",
@@ -574,6 +784,24 @@
                     "constraints": [],
                     "quote": null,
                     "tags": []
+                },
+                "order_id": {
+                    "name": "order_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "amount": {
+                    "name": "amount",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
                 }
             },
             "meta": {},
@@ -588,7 +816,7 @@
             "unrendered_config": {
                 "materialized": "view"
             },
-            "created_at": 1706145555.062218,
+            "created_at": 1708338357.5437949,
             "relation_name": "\"dbtmetabase\".\"public\".\"stg_payments\"",
             "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
             "language": "sql",
@@ -693,6 +921,24 @@
                     "constraints": [],
                     "quote": null,
                     "tags": []
+                },
+                "order_date": {
+                    "name": "order_date",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
                 }
             },
             "meta": {},
@@ -707,7 +953,7 @@
             "unrendered_config": {
                 "materialized": "view"
             },
-            "created_at": 1706145555.0616965,
+            "created_at": 1708338357.5444813,
             "relation_name": "\"dbtmetabase\".\"public\".\"stg_orders\"",
             "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
             "language": "sql",
@@ -741,1294 +987,6 @@
             "version": null,
             "latest_version": null,
             "deprecation_date": null
-        },
-        "seed.sandbox.raw_customers": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "raw_customers",
-            "resource_type": "seed",
-            "package_name": "sandbox",
-            "path": "raw_customers.csv",
-            "original_file_path": "seeds/raw_customers.csv",
-            "unique_id": "seed.sandbox.raw_customers",
-            "fqn": [
-                "sandbox",
-                "raw_customers"
-            ],
-            "alias": "raw_customers",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "357d173dda65a741ad97d6683502286cc2655bb396ab5f4dfad12b8c39bd2a63"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "seed",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "delimiter": ",",
-                "quote_columns": null
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145554.9672556,
-            "relation_name": "\"dbtmetabase\".\"public\".\"raw_customers\"",
-            "raw_code": "",
-            "root_path": "/app/sandbox",
-            "depends_on": {
-                "macros": []
-            }
-        },
-        "seed.sandbox.raw_orders": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "raw_orders",
-            "resource_type": "seed",
-            "package_name": "sandbox",
-            "path": "raw_orders.csv",
-            "original_file_path": "seeds/raw_orders.csv",
-            "unique_id": "seed.sandbox.raw_orders",
-            "fqn": [
-                "sandbox",
-                "raw_orders"
-            ],
-            "alias": "raw_orders",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "6228dde8e17b9621f35c13e272ec67d3ff55b55499433f47d303adf2be72c17f"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "seed",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "delimiter": ",",
-                "quote_columns": null
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145554.9684632,
-            "relation_name": "\"dbtmetabase\".\"public\".\"raw_orders\"",
-            "raw_code": "",
-            "root_path": "/app/sandbox",
-            "depends_on": {
-                "macros": []
-            }
-        },
-        "seed.sandbox.raw_payments": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "raw_payments",
-            "resource_type": "seed",
-            "package_name": "sandbox",
-            "path": "raw_payments.csv",
-            "original_file_path": "seeds/raw_payments.csv",
-            "unique_id": "seed.sandbox.raw_payments",
-            "fqn": [
-                "sandbox",
-                "raw_payments"
-            ],
-            "alias": "raw_payments",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "6de0626a8db9c1750eefd1b2e17fac4c2a4b9f778eb50532d8b377b90de395e6"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "seed",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "delimiter": ",",
-                "quote_columns": null
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145554.969442,
-            "relation_name": "\"dbtmetabase\".\"public\".\"raw_payments\"",
-            "raw_code": "",
-            "root_path": "/app/sandbox",
-            "depends_on": {
-                "macros": []
-            }
-        },
-        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": {
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "unique_customers_customer_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "unique_customers_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.unique_customers_customer_id.c5af1ff4b1",
-            "fqn": [
-                "sandbox",
-                "unique_customers_customer_id"
-            ],
-            "alias": "unique_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0420036,
-            "relation_name": null,
-            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.sandbox.customers"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.customers",
-            "attached_node": "model.sandbox.customers"
-        },
-        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_customers_customer_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_customers_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_customers_customer_id.5c9bf9911d",
-            "fqn": [
-                "sandbox",
-                "not_null_customers_customer_id"
-            ],
-            "alias": "not_null_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.043206,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.customers"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.customers",
-            "attached_node": "model.sandbox.customers"
-        },
-        "test.sandbox.unique_orders_order_id.fed79b3a6e": {
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "unique_orders_order_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "unique_orders_order_id.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.unique_orders_order_id.fed79b3a6e",
-            "fqn": [
-                "sandbox",
-                "unique_orders_order_id"
-            ],
-            "alias": "unique_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0442696,
-            "relation_name": null,
-            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "order_id",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_order_id.cf6c17daed": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_orders_order_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_orders_order_id.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_orders_order_id.cf6c17daed",
-            "fqn": [
-                "sandbox",
-                "not_null_orders_order_id"
-            ],
-            "alias": "not_null_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0451243,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "order_id",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_customer_id.c5f02694af": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_orders_customer_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_orders_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_orders_customer_id.c5f02694af",
-            "fqn": [
-                "sandbox",
-                "not_null_orders_customer_id"
-            ],
-            "alias": "not_null_orders_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.046102,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": {
-            "test_metadata": {
-                "name": "relationships",
-                "kwargs": {
-                    "to": "ref('customers')",
-                    "field": "customer_id",
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "relationships_orders_customer_id__customer_id__ref_customers_",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "relationships_orders_customer_id__customer_id__ref_customers_.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
-            "fqn": [
-                "sandbox",
-                "relationships_orders_customer_id__customer_id__ref_customers_"
-            ],
-            "alias": "relationships_orders_customer_id__customer_id__ref_customers_",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0468988,
-            "relation_name": null,
-            "raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "customers",
-                    "package": null,
-                    "version": null
-                },
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_relationships",
-                    "macro.dbt.get_where_subquery"
-                ],
-                "nodes": [
-                    "model.sandbox.customers",
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
-            "test_metadata": {
-                "name": "accepted_values",
-                "kwargs": {
-                    "values": [
-                        "placed",
-                        "shipped",
-                        "completed",
-                        "return_pending",
-                        "returned"
-                    ],
-                    "column_name": "status",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
-            "fqn": [
-                "sandbox",
-                "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
-            ],
-            "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {
-                "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
-            },
-            "created_at": 1706145555.0521317,
-            "relation_name": null,
-            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_accepted_values",
-                    "macro.dbt.get_where_subquery"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "status",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_amount.106140f9fd": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_orders_amount",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_orders_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_orders_amount.106140f9fd",
-            "fqn": [
-                "sandbox",
-                "not_null_orders_amount"
-            ],
-            "alias": "not_null_orders_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0571928,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "amount",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "credit_card_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_orders_credit_card_amount",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_orders_credit_card_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59",
-            "fqn": [
-                "sandbox",
-                "not_null_orders_credit_card_amount"
-            ],
-            "alias": "not_null_orders_credit_card_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0580268,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "credit_card_amount",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_coupon_amount.ab90c90625": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "coupon_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_orders_coupon_amount",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_orders_coupon_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_orders_coupon_amount.ab90c90625",
-            "fqn": [
-                "sandbox",
-                "not_null_orders_coupon_amount"
-            ],
-            "alias": "not_null_orders_coupon_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0588226,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "coupon_amount",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "bank_transfer_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_orders_bank_transfer_amount",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_orders_bank_transfer_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49",
-            "fqn": [
-                "sandbox",
-                "not_null_orders_bank_transfer_amount"
-            ],
-            "alias": "not_null_orders_bank_transfer_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0596151,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "bank_transfer_amount",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "gift_card_amount",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_orders_gift_card_amount",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_orders_gift_card_amount.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a",
-            "fqn": [
-                "sandbox",
-                "not_null_orders_gift_card_amount"
-            ],
-            "alias": "not_null_orders_gift_card_amount",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1706145555.0603943,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "gift_card_amount",
-            "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
         },
         "test.sandbox.unique_stg_customers_customer_id.c7614daada": {
             "test_metadata": {
@@ -2088,7 +1046,7 @@
             "build_path": null,
             "deferred": false,
             "unrendered_config": {},
-            "created_at": 1706145555.062559,
+            "created_at": 1708338357.5923638,
             "relation_name": null,
             "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2177,7 +1135,7 @@
             "build_path": null,
             "deferred": false,
             "unrendered_config": {},
-            "created_at": 1706145555.0633464,
+            "created_at": 1708338357.5937386,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2207,6 +1165,282 @@
             "column_name": "customer_id",
             "file_key_name": "models.stg_customers",
             "attached_node": "model.sandbox.stg_customers"
+        },
+        "test.sandbox.unique_stg_payments_payment_id.3744510712": {
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "payment_id",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "unique_stg_payments_payment_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "unique_stg_payments_payment_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.unique_stg_payments_payment_id.3744510712",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "unique_stg_payments_payment_id"
+            ],
+            "alias": "unique_stg_payments_payment_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708338357.595022,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_id",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.sandbox.stg_payments"
+        },
+        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": {
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "payment_id",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_stg_payments_payment_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_stg_payments_payment_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.not_null_stg_payments_payment_id.c19cc50075",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "not_null_stg_payments_payment_id"
+            ],
+            "alias": "not_null_stg_payments_payment_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708338357.5963225,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_id",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.sandbox.stg_payments"
+        },
+        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
+            "test_metadata": {
+                "name": "accepted_values",
+                "kwargs": {
+                    "values": [
+                        "credit_card",
+                        "coupon",
+                        "bank_transfer",
+                        "gift_card"
+                    ],
+                    "column_name": "payment_method",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
+            ],
+            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {
+                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+            },
+            "created_at": 1708338357.5973942,
+            "relation_name": null,
+            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_accepted_values",
+                    "macro.dbt.get_where_subquery"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_method",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.sandbox.stg_payments"
         },
         "test.sandbox.unique_stg_orders_order_id.e3b841c71a": {
             "test_metadata": {
@@ -2266,7 +1500,7 @@
             "build_path": null,
             "deferred": false,
             "unrendered_config": {},
-            "created_at": 1706145555.064111,
+            "created_at": 1708338357.6061413,
             "relation_name": null,
             "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2355,7 +1589,7 @@
             "build_path": null,
             "deferred": false,
             "unrendered_config": {},
-            "created_at": 1706145555.064856,
+            "created_at": 1708338357.6072319,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2453,7 +1687,7 @@
             "unrendered_config": {
                 "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
             },
-            "created_at": 1706145555.0657606,
+            "created_at": 1708338357.6084142,
             "relation_name": null,
             "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
             "language": "sql",
@@ -2485,29 +1719,241 @@
             "file_key_name": "models.stg_orders",
             "attached_node": "model.sandbox.stg_orders"
         },
-        "test.sandbox.unique_stg_payments_payment_id.3744510712": {
+        "model.sandbox.orders": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "orders",
+            "resource_type": "model",
+            "package_name": "sandbox",
+            "path": "orders.sql",
+            "original_file_path": "models/orders.sql",
+            "unique_id": "model.sandbox.orders",
+            "fqn": [
+                "sandbox",
+                "orders"
+            ],
+            "alias": "orders",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "9a13423dec138c8cedf1eb7e03f4ad86be3b378ef088ac9ecc09328b76d8986e"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {
+                    "metabase.points_of_interest": "Basic information only",
+                    "metabase.caveats": "Some facts are derived from payments"
+                },
+                "group": null,
+                "materialized": "table",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "This table has basic information about orders, as well as some derived facts based on payments",
+            "columns": {
+                "order_id": {
+                    "name": "order_id",
+                    "description": "This is a unique identifier for an order",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [
+                        {
+                            "type": "primary_key",
+                            "name": null,
+                            "expression": null,
+                            "warn_unenforced": true,
+                            "warn_unsupported": true
+                        }
+                    ],
+                    "quote": null,
+                    "tags": []
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "Foreign key to the customers table",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [
+                        {
+                            "type": "foreign_key",
+                            "name": null,
+                            "expression": "customers (customer_id)",
+                            "warn_unenforced": true,
+                            "warn_unsupported": true
+                        }
+                    ],
+                    "quote": null,
+                    "tags": []
+                },
+                "order_date": {
+                    "name": "order_date",
+                    "description": "Date (UTC) that the order was placed",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "status": {
+                    "name": "status",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "amount": {
+                    "name": "amount",
+                    "description": "Total amount (AUD) of the order",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "credit_card_amount": {
+                    "name": "credit_card_amount",
+                    "description": "Amount of the order (AUD) paid for by credit card",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "coupon_amount": {
+                    "name": "coupon_amount",
+                    "description": "Amount of the order (AUD) paid for by coupon",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "bank_transfer_amount": {
+                    "name": "bank_transfer_amount",
+                    "description": "Amount of the order (AUD) paid for by bank transfer",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "gift_card_amount": {
+                    "name": "gift_card_amount",
+                    "description": "Amount of the order (AUD) paid for by gift card",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {
+                "metabase.points_of_interest": "Basic information only",
+                "metabase.caveats": "Some facts are derived from payments"
+            },
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "sandbox://models/schema.yml",
+            "build_path": "target/run/sandbox/models/orders.sql",
+            "deferred": false,
+            "unrendered_config": {
+                "materialized": "table",
+                "meta": {
+                    "metabase.points_of_interest": "Basic information only",
+                    "metabase.caveats": "Some facts are derived from payments"
+                }
+            },
+            "created_at": 1708391489.32839,
+            "relation_name": "\"dbtmetabase\".\"public\".\"orders\"",
+            "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                },
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "model.sandbox.stg_orders",
+                    "model.sandbox.stg_payments"
+                ]
+            },
+            "compiled_path": "target/compiled/sandbox/models/orders.sql",
+            "compiled": true,
+            "compiled_code": "\n\nwith orders as (\n\n    select * from \"dbtmetabase\".\"public\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"dbtmetabase\".\"public\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "test.sandbox.unique_orders_order_id.fed79b3a6e": {
             "test_metadata": {
                 "name": "unique",
                 "kwargs": {
-                    "column_name": "payment_id",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
             },
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
-            "name": "unique_stg_payments_payment_id",
+            "name": "unique_orders_order_id",
             "resource_type": "test",
             "package_name": "sandbox",
-            "path": "unique_stg_payments_payment_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.unique_stg_payments_payment_id.3744510712",
+            "path": "unique_orders_order_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.unique_orders_order_id.fed79b3a6e",
             "fqn": [
                 "sandbox",
-                "staging",
-                "unique_stg_payments_payment_id"
+                "unique_orders_order_id"
             ],
-            "alias": "unique_stg_payments_payment_id",
+            "alias": "unique_orders_order_id",
             "checksum": {
                 "name": "none",
                 "checksum": ""
@@ -2543,13 +1989,13 @@
             "build_path": null,
             "deferred": false,
             "unrendered_config": {},
-            "created_at": 1706145555.0677629,
+            "created_at": 1708391489.3618965,
             "relation_name": null,
             "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
             "refs": [
                 {
-                    "name": "stg_payments",
+                    "name": "orders",
                     "package": null,
                     "version": null
                 }
@@ -2561,7 +2007,7 @@
                     "macro.dbt.test_unique"
                 ],
                 "nodes": [
-                    "model.sandbox.stg_payments"
+                    "model.sandbox.orders"
                 ]
             },
             "compiled_path": null,
@@ -2570,33 +2016,32 @@
                 "alias_types": true,
                 "checksum": null
             },
-            "column_name": "payment_id",
-            "file_key_name": "models.stg_payments",
-            "attached_node": "model.sandbox.stg_payments"
+            "column_name": "order_id",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
         },
-        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": {
+        "test.sandbox.not_null_orders_order_id.cf6c17daed": {
             "test_metadata": {
                 "name": "not_null",
                 "kwargs": {
-                    "column_name": "payment_id",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
             },
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
-            "name": "not_null_stg_payments_payment_id",
+            "name": "not_null_orders_order_id",
             "resource_type": "test",
             "package_name": "sandbox",
-            "path": "not_null_stg_payments_payment_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.not_null_stg_payments_payment_id.c19cc50075",
+            "path": "not_null_orders_order_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_orders_order_id.cf6c17daed",
             "fqn": [
                 "sandbox",
-                "staging",
-                "not_null_stg_payments_payment_id"
+                "not_null_orders_order_id"
             ],
-            "alias": "not_null_stg_payments_payment_id",
+            "alias": "not_null_orders_order_id",
             "checksum": {
                 "name": "none",
                 "checksum": ""
@@ -2632,13 +2077,13 @@
             "build_path": null,
             "deferred": false,
             "unrendered_config": {},
-            "created_at": 1706145555.0685904,
+            "created_at": 1708391489.362866,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
             "refs": [
                 {
-                    "name": "stg_payments",
+                    "name": "orders",
                     "package": null,
                     "version": null
                 }
@@ -2650,7 +2095,7 @@
                     "macro.dbt.test_not_null"
                 ],
                 "nodes": [
-                    "model.sandbox.stg_payments"
+                    "model.sandbox.orders"
                 ]
             },
             "compiled_path": null,
@@ -2659,46 +2104,134 @@
                 "alias_types": true,
                 "checksum": null
             },
-            "column_name": "payment_id",
-            "file_key_name": "models.stg_payments",
-            "attached_node": "model.sandbox.stg_payments"
+            "column_name": "order_id",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
         },
-        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
+        "test.sandbox.not_null_orders_customer_id.c5f02694af": {
             "test_metadata": {
-                "name": "accepted_values",
+                "name": "not_null",
                 "kwargs": {
-                    "values": [
-                        "credit_card",
-                        "coupon",
-                        "bank_transfer",
-                        "gift_card"
-                    ],
-                    "column_name": "payment_method",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
             },
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
-            "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+            "name": "not_null_orders_customer_id",
             "resource_type": "test",
             "package_name": "sandbox",
-            "path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+            "path": "not_null_orders_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_orders_customer_id.c5f02694af",
             "fqn": [
                 "sandbox",
-                "staging",
-                "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
+                "not_null_orders_customer_id"
             ],
-            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+            "alias": "not_null_orders_customer_id",
             "checksum": {
                 "name": "none",
                 "checksum": ""
             },
             "config": {
                 "enabled": true,
-                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708391489.3637223,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
+        },
+        "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
+            "test_metadata": {
+                "name": "accepted_values",
+                "kwargs": {
+                    "values": [
+                        "placed",
+                        "shipped",
+                        "completed",
+                        "return_pending",
+                        "returned"
+                    ],
+                    "column_name": "status",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+            "fqn": [
+                "sandbox",
+                "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
+            ],
+            "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
                 "schema": "dbt_test__audit",
                 "database": null,
                 "tags": [],
@@ -2727,15 +2260,15 @@
             "build_path": null,
             "deferred": false,
             "unrendered_config": {
-                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+                "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
             },
-            "created_at": 1706145555.0700967,
+            "created_at": 1708391489.3645678,
             "relation_name": null,
-            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
             "language": "sql",
             "refs": [
                 {
-                    "name": "stg_payments",
+                    "name": "orders",
                     "package": null,
                     "version": null
                 }
@@ -2748,7 +2281,7 @@
                     "macro.dbt.get_where_subquery"
                 ],
                 "nodes": [
-                    "model.sandbox.stg_payments"
+                    "model.sandbox.orders"
                 ]
             },
             "compiled_path": null,
@@ -2757,9 +2290,449 @@
                 "alias_types": true,
                 "checksum": null
             },
-            "column_name": "payment_method",
-            "file_key_name": "models.stg_payments",
-            "attached_node": "model.sandbox.stg_payments"
+            "column_name": "status",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
+        },
+        "test.sandbox.not_null_orders_amount.106140f9fd": {
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_orders_amount",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_orders_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_orders_amount.106140f9fd",
+            "fqn": [
+                "sandbox",
+                "not_null_orders_amount"
+            ],
+            "alias": "not_null_orders_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708391489.3704727,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
+        },
+        "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59": {
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "credit_card_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_orders_credit_card_amount",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_orders_credit_card_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59",
+            "fqn": [
+                "sandbox",
+                "not_null_orders_credit_card_amount"
+            ],
+            "alias": "not_null_orders_credit_card_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708391489.3713634,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "credit_card_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
+        },
+        "test.sandbox.not_null_orders_coupon_amount.ab90c90625": {
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "coupon_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_orders_coupon_amount",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_orders_coupon_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_orders_coupon_amount.ab90c90625",
+            "fqn": [
+                "sandbox",
+                "not_null_orders_coupon_amount"
+            ],
+            "alias": "not_null_orders_coupon_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708391489.3721504,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "coupon_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
+        },
+        "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49": {
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "bank_transfer_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_orders_bank_transfer_amount",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_orders_bank_transfer_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49",
+            "fqn": [
+                "sandbox",
+                "not_null_orders_bank_transfer_amount"
+            ],
+            "alias": "not_null_orders_bank_transfer_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708391489.3729131,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "bank_transfer_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
+        },
+        "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": {
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "gift_card_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            },
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_orders_gift_card_amount",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_orders_gift_card_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a",
+            "fqn": [
+                "sandbox",
+                "not_null_orders_gift_card_amount"
+            ],
+            "alias": "not_null_orders_gift_card_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1708391489.3737113,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "gift_card_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.sandbox.orders"
         }
     },
     "sources": {},
@@ -2783,7 +2756,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5681622,
+            "created_at": 1708330298.500109,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__snapshot_string_as_time": {
@@ -2805,7 +2778,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5683513,
+            "created_at": 1708330298.50035,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__snapshot_get_time": {
@@ -2829,7 +2802,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.568444,
+            "created_at": 1708330298.5004683,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__current_timestamp_backcompat": {
@@ -2853,7 +2826,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.568544,
+            "created_at": 1708330298.5006177,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__current_timestamp_in_utc_backcompat": {
@@ -2877,7 +2850,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5686326,
+            "created_at": 1708330298.500729,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__create_table_as": {
@@ -2904,7 +2877,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5763297,
+            "created_at": 1708330298.5101242,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_create_index_sql": {
@@ -2926,7 +2899,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5767663,
+            "created_at": 1708330298.5106356,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__create_schema": {
@@ -2950,7 +2923,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5770383,
+            "created_at": 1708330298.510947,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_schema": {
@@ -2974,7 +2947,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5772965,
+            "created_at": 1708330298.5112536,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_columns_in_relation": {
@@ -2999,7 +2972,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5776834,
+            "created_at": 1708330298.5117238,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__list_relations_without_caching": {
@@ -3023,7 +2996,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5781384,
+            "created_at": 1708330298.512267,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__information_schema_name": {
@@ -3045,7 +3018,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.578278,
+            "created_at": 1708330298.5124376,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__list_schemas": {
@@ -3069,7 +3042,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5785592,
+            "created_at": 1708330298.512787,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__check_schema_exists": {
@@ -3093,7 +3066,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.578856,
+            "created_at": 1708330298.513163,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_relation_with_suffix": {
@@ -3115,7 +3088,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5795238,
+            "created_at": 1708330298.5140045,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_intermediate_relation": {
@@ -3139,7 +3112,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5796766,
+            "created_at": 1708330298.514195,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_temp_relation": {
@@ -3163,7 +3136,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5799258,
+            "created_at": 1708330298.514516,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_backup_relation": {
@@ -3187,7 +3160,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.580137,
+            "created_at": 1708330298.5147827,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres_escape_comment": {
@@ -3209,7 +3182,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5804667,
+            "created_at": 1708330298.515186,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__alter_relation_comment": {
@@ -3233,7 +3206,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5806398,
+            "created_at": 1708330298.5154004,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__alter_column_comment": {
@@ -3257,7 +3230,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5810978,
+            "created_at": 1708330298.5159972,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_show_grant_sql": {
@@ -3279,7 +3252,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5812597,
+            "created_at": 1708330298.5162005,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__copy_grants": {
@@ -3301,7 +3274,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5813498,
+            "created_at": 1708330298.516311,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_show_indexes_sql": {
@@ -3323,7 +3296,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5815203,
+            "created_at": 1708330298.5165095,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_drop_index_sql": {
@@ -3345,7 +3318,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5816274,
+            "created_at": 1708330298.5166447,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_catalog_relations": {
@@ -3369,7 +3342,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5828412,
+            "created_at": 1708330298.5183465,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_catalog": {
@@ -3393,7 +3366,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.583115,
+            "created_at": 1708330298.5188854,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_relations": {
@@ -3417,7 +3390,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5836577,
+            "created_at": 1708330298.519621,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres_get_relations": {
@@ -3441,7 +3414,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5837507,
+            "created_at": 1708330298.519743,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_incremental_default_sql": {
@@ -3466,7 +3439,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5840359,
+            "created_at": 1708330298.5201066,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__snapshot_merge_sql": {
@@ -3488,7 +3461,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5845869,
+            "created_at": 1708330298.5208235,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_replace_view_sql": {
@@ -3512,7 +3485,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5850036,
+            "created_at": 1708330298.5213654,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_view": {
@@ -3534,7 +3507,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.585122,
+            "created_at": 1708330298.5215158,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_rename_view_sql": {
@@ -3556,7 +3529,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5852513,
+            "created_at": 1708330298.5216765,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_replace_table_sql": {
@@ -3582,7 +3555,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5858848,
+            "created_at": 1708330298.5223463,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_table": {
@@ -3604,7 +3577,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.58603,
+            "created_at": 1708330298.5224812,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_rename_table_sql": {
@@ -3626,7 +3599,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5861673,
+            "created_at": 1708330298.5226514,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__refresh_materialized_view": {
@@ -3648,7 +3621,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5862722,
+            "created_at": 1708330298.5227792,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__describe_materialized_view": {
@@ -3673,7 +3646,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.586539,
+            "created_at": 1708330298.523064,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_materialized_view": {
@@ -3695,7 +3668,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.586741,
+            "created_at": 1708330298.52329,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_rename_materialized_view_sql": {
@@ -3717,7 +3690,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5868738,
+            "created_at": 1708330298.5234535,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_alter_materialized_view_as_sql": {
@@ -3742,7 +3715,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5875628,
+            "created_at": 1708330298.524322,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__update_indexes_on_materialized_view": {
@@ -3767,7 +3740,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5879343,
+            "created_at": 1708330298.5248008,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_materialized_view_configuration_changes": {
@@ -3791,7 +3764,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5882244,
+            "created_at": 1708330298.52508,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_create_materialized_view_as_sql": {
@@ -3815,7 +3788,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5886245,
+            "created_at": 1708330298.5254297,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__listagg": {
@@ -3837,7 +3810,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5891001,
+            "created_at": 1708330298.5260458,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__dateadd": {
@@ -3859,7 +3832,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5892606,
+            "created_at": 1708330298.5262516,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__any_value": {
@@ -3881,7 +3854,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5893629,
+            "created_at": 1708330298.5263839,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__split_part": {
@@ -3906,7 +3879,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5896747,
+            "created_at": 1708330298.5267837,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__last_day": {
@@ -3932,7 +3905,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5900493,
+            "created_at": 1708330298.527255,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__datediff": {
@@ -3956,7 +3929,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.592488,
+            "created_at": 1708330298.5305197,
             "supported_languages": null
         },
         "macro.dbt.generate_database_name": {
@@ -3980,7 +3953,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5928009,
+            "created_at": 1708330298.5309165,
             "supported_languages": null
         },
         "macro.dbt.default__generate_database_name": {
@@ -4002,7 +3975,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.592988,
+            "created_at": 1708330298.5311565,
             "supported_languages": null
         },
         "macro.dbt.generate_schema_name": {
@@ -4026,7 +3999,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.59339,
+            "created_at": 1708330298.531699,
             "supported_languages": null
         },
         "macro.dbt.default__generate_schema_name": {
@@ -4048,7 +4021,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5935931,
+            "created_at": 1708330298.5319543,
             "supported_languages": null
         },
         "macro.dbt.generate_schema_name_for_env": {
@@ -4070,7 +4043,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5938025,
+            "created_at": 1708330298.5322382,
             "supported_languages": null
         },
         "macro.dbt.generate_alias_name": {
@@ -4094,7 +4067,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5941062,
+            "created_at": 1708330298.5326614,
             "supported_languages": null
         },
         "macro.dbt.default__generate_alias_name": {
@@ -4116,7 +4089,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5943813,
+            "created_at": 1708330298.5330265,
             "supported_languages": null
         },
         "macro.dbt.resolve_model_name": {
@@ -4140,7 +4113,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5956953,
+            "created_at": 1708330298.5347013,
             "supported_languages": null
         },
         "macro.dbt.default__resolve_model_name": {
@@ -4162,7 +4135,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5958927,
+            "created_at": 1708330298.5348513,
             "supported_languages": null
         },
         "macro.dbt.build_ref_function": {
@@ -4186,7 +4159,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5966134,
+            "created_at": 1708330298.535658,
             "supported_languages": null
         },
         "macro.dbt.build_source_function": {
@@ -4210,7 +4183,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5969474,
+            "created_at": 1708330298.536067,
             "supported_languages": null
         },
         "macro.dbt.build_config_dict": {
@@ -4232,7 +4205,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5973961,
+            "created_at": 1708330298.5366523,
             "supported_languages": null
         },
         "macro.dbt.py_script_postfix": {
@@ -4261,7 +4234,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5980356,
+            "created_at": 1708330298.5373712,
             "supported_languages": null
         },
         "macro.dbt.py_script_comment": {
@@ -4283,7 +4256,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.598095,
+            "created_at": 1708330298.537449,
             "supported_languages": null
         },
         "macro.dbt.run_hooks": {
@@ -4307,7 +4280,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5989525,
+            "created_at": 1708330298.5387776,
             "supported_languages": null
         },
         "macro.dbt.make_hook_config": {
@@ -4329,7 +4302,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5991056,
+            "created_at": 1708330298.5390067,
             "supported_languages": null
         },
         "macro.dbt.before_begin": {
@@ -4353,7 +4326,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.599219,
+            "created_at": 1708330298.5391488,
             "supported_languages": null
         },
         "macro.dbt.in_transaction": {
@@ -4377,7 +4350,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.599329,
+            "created_at": 1708330298.539292,
             "supported_languages": null
         },
         "macro.dbt.after_commit": {
@@ -4401,7 +4374,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.599435,
+            "created_at": 1708330298.5395236,
             "supported_languages": null
         },
         "macro.dbt.set_sql_header": {
@@ -4423,7 +4396,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5997381,
+            "created_at": 1708330298.5399194,
             "supported_languages": null
         },
         "macro.dbt.should_full_refresh": {
@@ -4445,7 +4418,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.5999718,
+            "created_at": 1708330298.5402334,
             "supported_languages": null
         },
         "macro.dbt.should_store_failures": {
@@ -4467,7 +4440,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.600199,
+            "created_at": 1708330298.540542,
             "supported_languages": null
         },
         "macro.dbt.materialization_test_default": {
@@ -4494,7 +4467,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6022599,
+            "created_at": 1708330298.5431957,
             "supported_languages": [
                 "sql"
             ]
@@ -4520,7 +4493,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6026115,
+            "created_at": 1708330298.5436575,
             "supported_languages": null
         },
         "macro.dbt.default__get_test_sql": {
@@ -4542,7 +4515,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6028411,
+            "created_at": 1708330298.5439508,
             "supported_languages": null
         },
         "macro.dbt.get_where_subquery": {
@@ -4566,7 +4539,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6031418,
+            "created_at": 1708330298.5443087,
             "supported_languages": null
         },
         "macro.dbt.default__get_where_subquery": {
@@ -4588,7 +4561,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6034262,
+            "created_at": 1708330298.5446825,
             "supported_languages": null
         },
         "macro.dbt.create_columns": {
@@ -4612,7 +4585,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6070242,
+            "created_at": 1708330298.549088,
             "supported_languages": null
         },
         "macro.dbt.default__create_columns": {
@@ -4636,7 +4609,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6072512,
+            "created_at": 1708330298.54937,
             "supported_languages": null
         },
         "macro.dbt.post_snapshot": {
@@ -4660,7 +4633,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.607383,
+            "created_at": 1708330298.5495458,
             "supported_languages": null
         },
         "macro.dbt.default__post_snapshot": {
@@ -4682,7 +4655,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6074603,
+            "created_at": 1708330298.549637,
             "supported_languages": null
         },
         "macro.dbt.get_true_sql": {
@@ -4706,7 +4679,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6075723,
+            "created_at": 1708330298.5497756,
             "supported_languages": null
         },
         "macro.dbt.default__get_true_sql": {
@@ -4728,7 +4701,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6076605,
+            "created_at": 1708330298.5498874,
             "supported_languages": null
         },
         "macro.dbt.snapshot_staging_table": {
@@ -4752,7 +4725,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6078143,
+            "created_at": 1708330298.5500886,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_staging_table": {
@@ -4776,7 +4749,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6085184,
+            "created_at": 1708330298.5510135,
             "supported_languages": null
         },
         "macro.dbt.build_snapshot_table": {
@@ -4800,7 +4773,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6086595,
+            "created_at": 1708330298.5511975,
             "supported_languages": null
         },
         "macro.dbt.default__build_snapshot_table": {
@@ -4822,7 +4795,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6088536,
+            "created_at": 1708330298.5514443,
             "supported_languages": null
         },
         "macro.dbt.build_snapshot_staging_table": {
@@ -4849,7 +4822,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6091673,
+            "created_at": 1708330298.55188,
             "supported_languages": null
         },
         "macro.dbt.materialization_snapshot_default": {
@@ -4886,7 +4859,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6140904,
+            "created_at": 1708330298.5586557,
             "supported_languages": [
                 "sql"
             ]
@@ -4912,7 +4885,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.614464,
+            "created_at": 1708330298.5591733,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_merge_sql": {
@@ -4934,7 +4907,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6146834,
+            "created_at": 1708330298.5594583,
             "supported_languages": null
         },
         "macro.dbt.strategy_dispatch": {
@@ -4956,7 +4929,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.617663,
+            "created_at": 1708330298.563218,
             "supported_languages": null
         },
         "macro.dbt.snapshot_hash_arguments": {
@@ -4980,7 +4953,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6177986,
+            "created_at": 1708330298.5633988,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_hash_arguments": {
@@ -5002,7 +4975,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6179757,
+            "created_at": 1708330298.5637388,
             "supported_languages": null
         },
         "macro.dbt.snapshot_timestamp_strategy": {
@@ -5026,7 +4999,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6185966,
+            "created_at": 1708330298.5645275,
             "supported_languages": null
         },
         "macro.dbt.snapshot_string_as_time": {
@@ -5050,7 +5023,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6187344,
+            "created_at": 1708330298.564707,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_string_as_time": {
@@ -5072,7 +5045,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.618874,
+            "created_at": 1708330298.5648892,
             "supported_languages": null
         },
         "macro.dbt.snapshot_check_all_get_existing_columns": {
@@ -5096,7 +5069,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6200058,
+            "created_at": 1708330298.5663006,
             "supported_languages": null
         },
         "macro.dbt.snapshot_check_strategy": {
@@ -5123,7 +5096,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6210408,
+            "created_at": 1708330298.5675998,
             "supported_languages": null
         },
         "macro.dbt.create_csv_table": {
@@ -5147,7 +5120,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6250587,
+            "created_at": 1708330298.572908,
             "supported_languages": null
         },
         "macro.dbt.default__create_csv_table": {
@@ -5171,7 +5144,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6257298,
+            "created_at": 1708330298.5737932,
             "supported_languages": null
         },
         "macro.dbt.reset_csv_table": {
@@ -5195,7 +5168,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6259162,
+            "created_at": 1708330298.5740166,
             "supported_languages": null
         },
         "macro.dbt.default__reset_csv_table": {
@@ -5219,7 +5192,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6262684,
+            "created_at": 1708330298.5744674,
             "supported_languages": null
         },
         "macro.dbt.get_csv_sql": {
@@ -5243,7 +5216,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.626413,
+            "created_at": 1708330298.5746727,
             "supported_languages": null
         },
         "macro.dbt.default__get_csv_sql": {
@@ -5265,7 +5238,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.626523,
+            "created_at": 1708330298.574799,
             "supported_languages": null
         },
         "macro.dbt.get_binding_char": {
@@ -5289,7 +5262,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6266289,
+            "created_at": 1708330298.5749333,
             "supported_languages": null
         },
         "macro.dbt.default__get_binding_char": {
@@ -5311,7 +5284,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6267116,
+            "created_at": 1708330298.5750396,
             "supported_languages": null
         },
         "macro.dbt.get_batch_size": {
@@ -5335,7 +5308,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.626845,
+            "created_at": 1708330298.5751874,
             "supported_languages": null
         },
         "macro.dbt.default__get_batch_size": {
@@ -5357,7 +5330,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6269305,
+            "created_at": 1708330298.5752983,
             "supported_languages": null
         },
         "macro.dbt.get_seed_column_quoted_csv": {
@@ -5379,7 +5352,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6273472,
+            "created_at": 1708330298.575762,
             "supported_languages": null
         },
         "macro.dbt.load_csv_rows": {
@@ -5403,7 +5376,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6275103,
+            "created_at": 1708330298.5759432,
             "supported_languages": null
         },
         "macro.dbt.default__load_csv_rows": {
@@ -5429,7 +5402,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6285172,
+            "created_at": 1708330298.5772634,
             "supported_languages": null
         },
         "macro.dbt.materialization_seed_default": {
@@ -5463,7 +5436,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.630931,
+            "created_at": 1708330298.5807245,
             "supported_languages": [
                 "sql"
             ]
@@ -5499,7 +5472,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.633134,
+            "created_at": 1708330298.583626,
             "supported_languages": [
                 "sql"
             ]
@@ -5534,7 +5507,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6353793,
+            "created_at": 1708330298.5865545,
             "supported_languages": [
                 "sql"
             ]
@@ -5567,7 +5540,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6393204,
+            "created_at": 1708330298.5918787,
             "supported_languages": [
                 "sql"
             ]
@@ -5595,7 +5568,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.639623,
+            "created_at": 1708330298.5922709,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_teardown": {
@@ -5620,7 +5593,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6398118,
+            "created_at": 1708330298.5925407,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_get_build_sql": {
@@ -5649,7 +5622,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.640766,
+            "created_at": 1708330298.593817,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_execute_no_op": {
@@ -5671,7 +5644,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6409376,
+            "created_at": 1708330298.5940437,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_execute_build_sql": {
@@ -5699,7 +5672,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6414285,
+            "created_at": 1708330298.5946872,
             "supported_languages": null
         },
         "macro.dbt.incremental_validate_on_schema_change": {
@@ -5721,7 +5694,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6458056,
+            "created_at": 1708330298.6007638,
             "supported_languages": null
         },
         "macro.dbt.check_for_schema_changes": {
@@ -5746,7 +5719,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6467223,
+            "created_at": 1708330298.6020534,
             "supported_languages": null
         },
         "macro.dbt.sync_column_schemas": {
@@ -5771,7 +5744,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.647604,
+            "created_at": 1708330298.6033158,
             "supported_languages": null
         },
         "macro.dbt.process_schema_changes": {
@@ -5796,7 +5769,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.64823,
+            "created_at": 1708330298.6042094,
             "supported_languages": null
         },
         "macro.dbt.get_merge_sql": {
@@ -5820,7 +5793,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6534753,
+            "created_at": 1708330298.6113167,
             "supported_languages": null
         },
         "macro.dbt.default__get_merge_sql": {
@@ -5845,7 +5818,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6546695,
+            "created_at": 1708330298.612972,
             "supported_languages": null
         },
         "macro.dbt.get_delete_insert_merge_sql": {
@@ -5869,7 +5842,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.654864,
+            "created_at": 1708330298.6132426,
             "supported_languages": null
         },
         "macro.dbt.default__get_delete_insert_merge_sql": {
@@ -5893,7 +5866,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6556215,
+            "created_at": 1708330298.614259,
             "supported_languages": null
         },
         "macro.dbt.get_insert_overwrite_merge_sql": {
@@ -5917,7 +5890,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.65582,
+            "created_at": 1708330298.6145384,
             "supported_languages": null
         },
         "macro.dbt.default__get_insert_overwrite_merge_sql": {
@@ -5941,7 +5914,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6562977,
+            "created_at": 1708330298.615291,
             "supported_languages": null
         },
         "macro.dbt.get_quoted_csv": {
@@ -5963,7 +5936,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6575282,
+            "created_at": 1708330298.6169353,
             "supported_languages": null
         },
         "macro.dbt.diff_columns": {
@@ -5985,7 +5958,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6579359,
+            "created_at": 1708330298.6174629,
             "supported_languages": null
         },
         "macro.dbt.diff_column_data_types": {
@@ -6007,7 +5980,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6585205,
+            "created_at": 1708330298.6182358,
             "supported_languages": null
         },
         "macro.dbt.get_merge_update_columns": {
@@ -6031,7 +6004,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6586964,
+            "created_at": 1708330298.618634,
             "supported_languages": null
         },
         "macro.dbt.default__get_merge_update_columns": {
@@ -6053,7 +6026,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6592205,
+            "created_at": 1708330298.6195307,
             "supported_languages": null
         },
         "macro.dbt.is_incremental": {
@@ -6077,7 +6050,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6597126,
+            "created_at": 1708330298.6202323,
             "supported_languages": null
         },
         "macro.dbt.materialization_incremental_default": {
@@ -6116,7 +6089,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6634784,
+            "created_at": 1708330298.6252937,
             "supported_languages": [
                 "sql"
             ]
@@ -6142,7 +6115,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6641579,
+            "created_at": 1708330298.6262195,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_append_sql": {
@@ -6166,7 +6139,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6643257,
+            "created_at": 1708330298.6264565,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_delete_insert_sql": {
@@ -6190,7 +6163,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6644704,
+            "created_at": 1708330298.6266503,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_delete_insert_sql": {
@@ -6214,7 +6187,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.664682,
+            "created_at": 1708330298.6269372,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_merge_sql": {
@@ -6238,7 +6211,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6648176,
+            "created_at": 1708330298.6271317,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_merge_sql": {
@@ -6262,7 +6235,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6650286,
+            "created_at": 1708330298.6274204,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_insert_overwrite_sql": {
@@ -6286,7 +6259,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6651597,
+            "created_at": 1708330298.62761,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_insert_overwrite_sql": {
@@ -6310,7 +6283,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6653452,
+            "created_at": 1708330298.6278706,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_default_sql": {
@@ -6334,7 +6307,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6654878,
+            "created_at": 1708330298.6280508,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_default_sql": {
@@ -6358,7 +6331,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6655974,
+            "created_at": 1708330298.628201,
             "supported_languages": null
         },
         "macro.dbt.get_insert_into_sql": {
@@ -6382,7 +6355,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6658008,
+            "created_at": 1708330298.6284833,
             "supported_languages": null
         },
         "macro.dbt.can_clone_table": {
@@ -6406,7 +6379,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.665979,
+            "created_at": 1708330298.6287339,
             "supported_languages": null
         },
         "macro.dbt.default__can_clone_table": {
@@ -6428,7 +6401,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.666064,
+            "created_at": 1708330298.6288488,
             "supported_languages": null
         },
         "macro.dbt.create_or_replace_clone": {
@@ -6452,7 +6425,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.666278,
+            "created_at": 1708330298.6292129,
             "supported_languages": null
         },
         "macro.dbt.default__create_or_replace_clone": {
@@ -6474,7 +6447,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6663783,
+            "created_at": 1708330298.6293995,
             "supported_languages": null
         },
         "macro.dbt.materialization_clone_default": {
@@ -6505,7 +6478,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6691573,
+            "created_at": 1708330298.6333277,
             "supported_languages": [
                 "sql"
             ]
@@ -6531,7 +6504,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6698363,
+            "created_at": 1708330298.6342292,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_sql": {
@@ -6563,7 +6536,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6707203,
+            "created_at": 1708330298.6354191,
             "supported_languages": null
         },
         "macro.dbt.get_create_backup_sql": {
@@ -6587,7 +6560,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6709929,
+            "created_at": 1708330298.6358008,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_backup_sql": {
@@ -6613,7 +6586,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.671187,
+            "created_at": 1708330298.6360586,
             "supported_languages": null
         },
         "macro.dbt.get_drop_sql": {
@@ -6637,7 +6610,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6717353,
+            "created_at": 1708330298.6367738,
             "supported_languages": null
         },
         "macro.dbt.default__get_drop_sql": {
@@ -6663,7 +6636,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6719952,
+            "created_at": 1708330298.6371417,
             "supported_languages": null
         },
         "macro.dbt.drop_relation": {
@@ -6687,7 +6660,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6721287,
+            "created_at": 1708330298.6373215,
             "supported_languages": null
         },
         "macro.dbt.default__drop_relation": {
@@ -6712,7 +6685,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.672272,
+            "created_at": 1708330298.6375327,
             "supported_languages": null
         },
         "macro.dbt.drop_relation_if_exists": {
@@ -6734,7 +6707,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6724102,
+            "created_at": 1708330298.6377306,
             "supported_languages": null
         },
         "macro.dbt.get_rename_sql": {
@@ -6758,7 +6731,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6729453,
+            "created_at": 1708330298.6384318,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_sql": {
@@ -6784,7 +6757,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6732552,
+            "created_at": 1708330298.6388555,
             "supported_languages": null
         },
         "macro.dbt.rename_relation": {
@@ -6808,7 +6781,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.673405,
+            "created_at": 1708330298.6390538,
             "supported_languages": null
         },
         "macro.dbt.default__rename_relation": {
@@ -6832,7 +6805,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6736226,
+            "created_at": 1708330298.6393352,
             "supported_languages": null
         },
         "macro.dbt.get_create_intermediate_sql": {
@@ -6856,7 +6829,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.673898,
+            "created_at": 1708330298.6397078,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_intermediate_sql": {
@@ -6882,7 +6855,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6740813,
+            "created_at": 1708330298.6399567,
             "supported_languages": null
         },
         "macro.dbt.get_drop_backup_sql": {
@@ -6906,7 +6879,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6743135,
+            "created_at": 1708330298.640266,
             "supported_languages": null
         },
         "macro.dbt.default__get_drop_backup_sql": {
@@ -6931,7 +6904,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6744716,
+            "created_at": 1708330298.6404645,
             "supported_languages": null
         },
         "macro.dbt.get_create_sql": {
@@ -6955,7 +6928,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6748202,
+            "created_at": 1708330298.6409438,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_sql": {
@@ -6981,7 +6954,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.675137,
+            "created_at": 1708330298.6413696,
             "supported_languages": null
         },
         "macro.dbt.get_rename_intermediate_sql": {
@@ -7005,7 +6978,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6753833,
+            "created_at": 1708330298.641697,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_intermediate_sql": {
@@ -7030,7 +7003,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.675544,
+            "created_at": 1708330298.6418974,
             "supported_languages": null
         },
         "macro.dbt.get_table_columns_and_constraints": {
@@ -7054,7 +7027,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.676307,
+            "created_at": 1708330298.6429393,
             "supported_languages": null
         },
         "macro.dbt.default__get_table_columns_and_constraints": {
@@ -7078,7 +7051,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.676395,
+            "created_at": 1708330298.6430545,
             "supported_languages": null
         },
         "macro.dbt.table_columns_and_constraints": {
@@ -7100,7 +7073,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.676791,
+            "created_at": 1708330298.6436424,
             "supported_languages": null
         },
         "macro.dbt.get_assert_columns_equivalent": {
@@ -7124,7 +7097,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6769798,
+            "created_at": 1708330298.6438968,
             "supported_languages": null
         },
         "macro.dbt.default__get_assert_columns_equivalent": {
@@ -7148,7 +7121,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.677078,
+            "created_at": 1708330298.644028,
             "supported_languages": null
         },
         "macro.dbt.assert_columns_equivalent": {
@@ -7174,7 +7147,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6780024,
+            "created_at": 1708330298.6452618,
             "supported_languages": null
         },
         "macro.dbt.format_columns": {
@@ -7198,7 +7171,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6782806,
+            "created_at": 1708330298.6456428,
             "supported_languages": null
         },
         "macro.dbt.default__format_column": {
@@ -7220,7 +7193,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6785462,
+            "created_at": 1708330298.6459916,
             "supported_languages": null
         },
         "macro.dbt.get_replace_view_sql": {
@@ -7244,7 +7217,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6792011,
+            "created_at": 1708330298.6468515,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_view_sql": {
@@ -7266,7 +7239,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6793077,
+            "created_at": 1708330298.6469932,
             "supported_languages": null
         },
         "macro.dbt.create_or_replace_view": {
@@ -7296,7 +7269,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6801229,
+            "created_at": 1708330298.6480694,
             "supported_languages": null
         },
         "macro.dbt.handle_existing_table": {
@@ -7320,7 +7293,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6802635,
+            "created_at": 1708330298.648259,
             "supported_languages": null
         },
         "macro.dbt.default__handle_existing_table": {
@@ -7342,7 +7315,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.680422,
+            "created_at": 1708330298.6484735,
             "supported_languages": null
         },
         "macro.dbt.drop_view": {
@@ -7366,7 +7339,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6806257,
+            "created_at": 1708330298.6487405,
             "supported_languages": null
         },
         "macro.dbt.default__drop_view": {
@@ -7388,7 +7361,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6807032,
+            "created_at": 1708330298.6488426,
             "supported_languages": null
         },
         "macro.dbt.get_rename_view_sql": {
@@ -7412,7 +7385,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6809,
+            "created_at": 1708330298.649106,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_view_sql": {
@@ -7434,7 +7407,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6810055,
+            "created_at": 1708330298.6492453,
             "supported_languages": null
         },
         "macro.dbt.get_create_view_as_sql": {
@@ -7458,7 +7431,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.681312,
+            "created_at": 1708330298.6496537,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_view_as_sql": {
@@ -7482,7 +7455,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.68143,
+            "created_at": 1708330298.649803,
             "supported_languages": null
         },
         "macro.dbt.create_view_as": {
@@ -7506,7 +7479,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.681569,
+            "created_at": 1708330298.6499746,
             "supported_languages": null
         },
         "macro.dbt.default__create_view_as": {
@@ -7530,7 +7503,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6818724,
+            "created_at": 1708330298.6503804,
             "supported_languages": null
         },
         "macro.dbt.get_replace_table_sql": {
@@ -7554,7 +7527,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.682073,
+            "created_at": 1708330298.6506543,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_table_sql": {
@@ -7576,7 +7549,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6821785,
+            "created_at": 1708330298.650794,
             "supported_languages": null
         },
         "macro.dbt.drop_table": {
@@ -7600,7 +7573,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.682369,
+            "created_at": 1708330298.6510668,
             "supported_languages": null
         },
         "macro.dbt.default__drop_table": {
@@ -7622,7 +7595,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6824481,
+            "created_at": 1708330298.6512222,
             "supported_languages": null
         },
         "macro.dbt.get_rename_table_sql": {
@@ -7646,7 +7619,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6826518,
+            "created_at": 1708330298.651542,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_table_sql": {
@@ -7668,7 +7641,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.682761,
+            "created_at": 1708330298.6517115,
             "supported_languages": null
         },
         "macro.dbt.get_create_table_as_sql": {
@@ -7692,7 +7665,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.683403,
+            "created_at": 1708330298.6526318,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_table_as_sql": {
@@ -7716,7 +7689,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6835518,
+            "created_at": 1708330298.6528091,
             "supported_languages": null
         },
         "macro.dbt.create_table_as": {
@@ -7740,7 +7713,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6839387,
+            "created_at": 1708330298.6533344,
             "supported_languages": null
         },
         "macro.dbt.default__create_table_as": {
@@ -7766,7 +7739,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.684438,
+            "created_at": 1708330298.654016,
             "supported_languages": null
         },
         "macro.dbt.default__get_column_names": {
@@ -7788,7 +7761,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6847801,
+            "created_at": 1708330298.6544642,
             "supported_languages": null
         },
         "macro.dbt.get_select_subquery": {
@@ -7812,7 +7785,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6849122,
+            "created_at": 1708330298.6546543,
             "supported_languages": null
         },
         "macro.dbt.default__get_select_subquery": {
@@ -7836,7 +7809,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.685039,
+            "created_at": 1708330298.6548293,
             "supported_languages": null
         },
         "macro.dbt.refresh_materialized_view": {
@@ -7860,7 +7833,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6852703,
+            "created_at": 1708330298.6551301,
             "supported_languages": null
         },
         "macro.dbt.default__refresh_materialized_view": {
@@ -7882,7 +7855,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.685366,
+            "created_at": 1708330298.6552625,
             "supported_languages": null
         },
         "macro.dbt.get_replace_materialized_view_sql": {
@@ -7906,7 +7879,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6855707,
+            "created_at": 1708330298.655537,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_materialized_view_sql": {
@@ -7928,7 +7901,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.685677,
+            "created_at": 1708330298.6556823,
             "supported_languages": null
         },
         "macro.dbt.drop_materialized_view": {
@@ -7952,7 +7925,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6858692,
+            "created_at": 1708330298.6559346,
             "supported_languages": null
         },
         "macro.dbt.default__drop_materialized_view": {
@@ -7974,7 +7947,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.685948,
+            "created_at": 1708330298.6560376,
             "supported_languages": null
         },
         "macro.dbt.get_rename_materialized_view_sql": {
@@ -7998,7 +7971,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6861484,
+            "created_at": 1708330298.6562972,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_materialized_view_sql": {
@@ -8020,7 +7993,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6862562,
+            "created_at": 1708330298.65644,
             "supported_languages": null
         },
         "macro.dbt.get_alter_materialized_view_as_sql": {
@@ -8044,7 +8017,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6867146,
+            "created_at": 1708330298.6570497,
             "supported_languages": null
         },
         "macro.dbt.default__get_alter_materialized_view_as_sql": {
@@ -8066,7 +8039,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6868513,
+            "created_at": 1708330298.6572325,
             "supported_languages": null
         },
         "macro.dbt.get_materialized_view_configuration_changes": {
@@ -8090,7 +8063,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.68706,
+            "created_at": 1708330298.6575205,
             "supported_languages": null
         },
         "macro.dbt.default__get_materialized_view_configuration_changes": {
@@ -8112,7 +8085,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.687166,
+            "created_at": 1708330298.6576629,
             "supported_languages": null
         },
         "macro.dbt.get_create_materialized_view_as_sql": {
@@ -8136,7 +8109,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6873653,
+            "created_at": 1708330298.6579247,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_materialized_view_as_sql": {
@@ -8158,7 +8131,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6874814,
+            "created_at": 1708330298.6580632,
             "supported_languages": null
         },
         "macro.dbt.default__test_accepted_values": {
@@ -8180,7 +8153,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6879034,
+            "created_at": 1708330298.6586328,
             "supported_languages": null
         },
         "macro.dbt.default__test_not_null": {
@@ -8204,7 +8177,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6881247,
+            "created_at": 1708330298.658927,
             "supported_languages": null
         },
         "macro.dbt.default__test_relationships": {
@@ -8226,7 +8199,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6883876,
+            "created_at": 1708330298.6592968,
             "supported_languages": null
         },
         "macro.dbt.default__test_unique": {
@@ -8248,7 +8221,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6885736,
+            "created_at": 1708330298.6595511,
             "supported_languages": null
         },
         "macro.dbt.listagg": {
@@ -8272,7 +8245,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6890483,
+            "created_at": 1708330298.6601758,
             "supported_languages": null
         },
         "macro.dbt.default__listagg": {
@@ -8294,7 +8267,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.689351,
+            "created_at": 1708330298.6605818,
             "supported_languages": null
         },
         "macro.dbt.safe_cast": {
@@ -8318,7 +8291,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6895661,
+            "created_at": 1708330298.6608617,
             "supported_languages": null
         },
         "macro.dbt.default__safe_cast": {
@@ -8340,7 +8313,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6896698,
+            "created_at": 1708330298.661014,
             "supported_languages": null
         },
         "macro.dbt.intersect": {
@@ -8364,7 +8337,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6898313,
+            "created_at": 1708330298.6612434,
             "supported_languages": null
         },
         "macro.dbt.default__intersect": {
@@ -8386,7 +8359,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6898885,
+            "created_at": 1708330298.6613193,
             "supported_languages": null
         },
         "macro.dbt.except": {
@@ -8410,7 +8383,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6901135,
+            "created_at": 1708330298.6617448,
             "supported_languages": null
         },
         "macro.dbt.default__except": {
@@ -8432,7 +8405,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6901712,
+            "created_at": 1708330298.661872,
             "supported_languages": null
         },
         "macro.dbt.get_powers_of_two": {
@@ -8456,7 +8429,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.69081,
+            "created_at": 1708330298.6627808,
             "supported_languages": null
         },
         "macro.dbt.default__get_powers_of_two": {
@@ -8478,7 +8451,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6911185,
+            "created_at": 1708330298.6632087,
             "supported_languages": null
         },
         "macro.dbt.generate_series": {
@@ -8502,7 +8475,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6912532,
+            "created_at": 1708330298.6633935,
             "supported_languages": null
         },
         "macro.dbt.default__generate_series": {
@@ -8526,7 +8499,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6916382,
+            "created_at": 1708330298.6639416,
             "supported_languages": null
         },
         "macro.dbt.replace": {
@@ -8550,7 +8523,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6918845,
+            "created_at": 1708330298.6642861,
             "supported_languages": null
         },
         "macro.dbt.default__replace": {
@@ -8572,7 +8545,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6920025,
+            "created_at": 1708330298.664454,
             "supported_languages": null
         },
         "macro.dbt.get_intervals_between": {
@@ -8596,7 +8569,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6925623,
+            "created_at": 1708330298.6652257,
             "supported_languages": null
         },
         "macro.dbt.default__get_intervals_between": {
@@ -8621,7 +8594,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6929936,
+            "created_at": 1708330298.6658232,
             "supported_languages": null
         },
         "macro.dbt.date_spine": {
@@ -8645,7 +8618,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6931622,
+            "created_at": 1708330298.6660545,
             "supported_languages": null
         },
         "macro.dbt.default__date_spine": {
@@ -8671,7 +8644,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.693432,
+            "created_at": 1708330298.6664183,
             "supported_languages": null
         },
         "macro.dbt.hash": {
@@ -8695,7 +8668,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6936297,
+            "created_at": 1708330298.6666849,
             "supported_languages": null
         },
         "macro.dbt.default__hash": {
@@ -8717,7 +8690,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6937442,
+            "created_at": 1708330298.6668458,
             "supported_languages": null
         },
         "macro.dbt.concat": {
@@ -8741,7 +8714,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6939178,
+            "created_at": 1708330298.6671133,
             "supported_languages": null
         },
         "macro.dbt.default__concat": {
@@ -8763,7 +8736,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6940048,
+            "created_at": 1708330298.6672306,
             "supported_languages": null
         },
         "macro.dbt.string_literal": {
@@ -8787,7 +8760,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6941786,
+            "created_at": 1708330298.6675715,
             "supported_languages": null
         },
         "macro.dbt.default__string_literal": {
@@ -8809,7 +8782,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6942525,
+            "created_at": 1708330298.667697,
             "supported_languages": null
         },
         "macro.dbt.type_string": {
@@ -8833,7 +8806,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6950414,
+            "created_at": 1708330298.6687655,
             "supported_languages": null
         },
         "macro.dbt.default__type_string": {
@@ -8855,7 +8828,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.695152,
+            "created_at": 1708330298.668916,
             "supported_languages": null
         },
         "macro.dbt.type_timestamp": {
@@ -8879,7 +8852,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.69527,
+            "created_at": 1708330298.6690693,
             "supported_languages": null
         },
         "macro.dbt.default__type_timestamp": {
@@ -8901,7 +8874,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6953776,
+            "created_at": 1708330298.669215,
             "supported_languages": null
         },
         "macro.dbt.type_float": {
@@ -8925,7 +8898,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6955047,
+            "created_at": 1708330298.6693678,
             "supported_languages": null
         },
         "macro.dbt.default__type_float": {
@@ -8947,7 +8920,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6956182,
+            "created_at": 1708330298.6695323,
             "supported_languages": null
         },
         "macro.dbt.type_numeric": {
@@ -8971,7 +8944,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6957312,
+            "created_at": 1708330298.6696868,
             "supported_languages": null
         },
         "macro.dbt.default__type_numeric": {
@@ -8993,7 +8966,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.695857,
+            "created_at": 1708330298.6698532,
             "supported_languages": null
         },
         "macro.dbt.type_bigint": {
@@ -9017,7 +8990,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6959705,
+            "created_at": 1708330298.6700027,
             "supported_languages": null
         },
         "macro.dbt.default__type_bigint": {
@@ -9039,7 +9012,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6961434,
+            "created_at": 1708330298.6702461,
             "supported_languages": null
         },
         "macro.dbt.type_int": {
@@ -9063,7 +9036,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6962574,
+            "created_at": 1708330298.670405,
             "supported_languages": null
         },
         "macro.dbt.default__type_int": {
@@ -9085,7 +9058,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6963584,
+            "created_at": 1708330298.670555,
             "supported_languages": null
         },
         "macro.dbt.type_boolean": {
@@ -9109,7 +9082,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.696479,
+            "created_at": 1708330298.6707082,
             "supported_languages": null
         },
         "macro.dbt.default__type_boolean": {
@@ -9131,7 +9104,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6965823,
+            "created_at": 1708330298.6708455,
             "supported_languages": null
         },
         "macro.dbt.array_construct": {
@@ -9155,7 +9128,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.696855,
+            "created_at": 1708330298.6712036,
             "supported_languages": null
         },
         "macro.dbt.default__array_construct": {
@@ -9177,7 +9150,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6970685,
+            "created_at": 1708330298.6714365,
             "supported_languages": null
         },
         "macro.dbt.cast_bool_to_text": {
@@ -9201,7 +9174,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.697262,
+            "created_at": 1708330298.6717927,
             "supported_languages": null
         },
         "macro.dbt.default__cast_bool_to_text": {
@@ -9223,7 +9196,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6973813,
+            "created_at": 1708330298.671995,
             "supported_languages": null
         },
         "macro.dbt.bool_or": {
@@ -9247,7 +9220,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.697574,
+            "created_at": 1708330298.6722603,
             "supported_languages": null
         },
         "macro.dbt.default__bool_or": {
@@ -9269,7 +9242,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6976514,
+            "created_at": 1708330298.6723726,
             "supported_languages": null
         },
         "macro.dbt.dateadd": {
@@ -9293,7 +9266,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.697899,
+            "created_at": 1708330298.6727378,
             "supported_languages": null
         },
         "macro.dbt.default__dateadd": {
@@ -9315,7 +9288,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6980197,
+            "created_at": 1708330298.6729088,
             "supported_languages": null
         },
         "macro.dbt.any_value": {
@@ -9339,7 +9312,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6981988,
+            "created_at": 1708330298.673148,
             "supported_languages": null
         },
         "macro.dbt.default__any_value": {
@@ -9361,7 +9334,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6982768,
+            "created_at": 1708330298.6732557,
             "supported_languages": null
         },
         "macro.dbt.split_part": {
@@ -9385,7 +9358,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6986735,
+            "created_at": 1708330298.6738064,
             "supported_languages": null
         },
         "macro.dbt.default__split_part": {
@@ -9407,7 +9380,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6987917,
+            "created_at": 1708330298.673971,
             "supported_languages": null
         },
         "macro.dbt._split_part_negative": {
@@ -9429,7 +9402,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6989524,
+            "created_at": 1708330298.6741853,
             "supported_languages": null
         },
         "macro.dbt.length": {
@@ -9453,7 +9426,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6991348,
+            "created_at": 1708330298.674433,
             "supported_languages": null
         },
         "macro.dbt.default__length": {
@@ -9475,7 +9448,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6992104,
+            "created_at": 1708330298.6745496,
             "supported_languages": null
         },
         "macro.dbt.right": {
@@ -9499,7 +9472,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6994207,
+            "created_at": 1708330298.6748302,
             "supported_languages": null
         },
         "macro.dbt.default__right": {
@@ -9521,7 +9494,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.699532,
+            "created_at": 1708330298.6749709,
             "supported_languages": null
         },
         "macro.dbt.position": {
@@ -9545,7 +9518,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.699738,
+            "created_at": 1708330298.6752727,
             "supported_languages": null
         },
         "macro.dbt.default__position": {
@@ -9567,7 +9540,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.6998453,
+            "created_at": 1708330298.675453,
             "supported_languages": null
         },
         "macro.dbt.date_trunc": {
@@ -9591,7 +9564,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7000463,
+            "created_at": 1708330298.6757562,
             "supported_languages": null
         },
         "macro.dbt.default__date_trunc": {
@@ -9613,7 +9586,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7001402,
+            "created_at": 1708330298.6758823,
             "supported_languages": null
         },
         "macro.dbt.last_day": {
@@ -9637,7 +9610,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7003872,
+            "created_at": 1708330298.676216,
             "supported_languages": null
         },
         "macro.dbt.default_last_day": {
@@ -9662,7 +9635,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7006617,
+            "created_at": 1708330298.676614,
             "supported_languages": null
         },
         "macro.dbt.default__last_day": {
@@ -9686,7 +9659,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7007701,
+            "created_at": 1708330298.6767573,
             "supported_languages": null
         },
         "macro.dbt.escape_single_quotes": {
@@ -9710,7 +9683,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7009664,
+            "created_at": 1708330298.6770108,
             "supported_languages": null
         },
         "macro.dbt.default__escape_single_quotes": {
@@ -9732,7 +9705,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7010655,
+            "created_at": 1708330298.6771474,
             "supported_languages": null
         },
         "macro.dbt.datediff": {
@@ -9756,7 +9729,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7013066,
+            "created_at": 1708330298.677466,
             "supported_languages": null
         },
         "macro.dbt.default__datediff": {
@@ -9778,7 +9751,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7014256,
+            "created_at": 1708330298.6776445,
             "supported_languages": null
         },
         "macro.dbt.array_append": {
@@ -9802,7 +9775,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7016346,
+            "created_at": 1708330298.6779194,
             "supported_languages": null
         },
         "macro.dbt.default__array_append": {
@@ -9824,7 +9797,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7017322,
+            "created_at": 1708330298.678047,
             "supported_languages": null
         },
         "macro.dbt.array_concat": {
@@ -9848,7 +9821,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7019274,
+            "created_at": 1708330298.6783056,
             "supported_languages": null
         },
         "macro.dbt.default__array_concat": {
@@ -9870,7 +9843,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7020214,
+            "created_at": 1708330298.678443,
             "supported_languages": null
         },
         "macro.dbt.convert_datetime": {
@@ -9892,7 +9865,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7034445,
+            "created_at": 1708330298.680482,
             "supported_languages": null
         },
         "macro.dbt.dates_in_range": {
@@ -9916,7 +9889,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7043116,
+            "created_at": 1708330298.6818788,
             "supported_languages": null
         },
         "macro.dbt.partition_range": {
@@ -9940,7 +9913,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7048607,
+            "created_at": 1708330298.6826746,
             "supported_languages": null
         },
         "macro.dbt.py_current_timestring": {
@@ -9962,7 +9935,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7050266,
+            "created_at": 1708330298.6829095,
             "supported_languages": null
         },
         "macro.dbt.statement": {
@@ -9984,7 +9957,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7061265,
+            "created_at": 1708330298.6844487,
             "supported_languages": null
         },
         "macro.dbt.noop_statement": {
@@ -10006,7 +9979,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7065449,
+            "created_at": 1708330298.6850069,
             "supported_languages": null
         },
         "macro.dbt.run_query": {
@@ -10030,7 +10003,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7067552,
+            "created_at": 1708330298.6852882,
             "supported_languages": null
         },
         "macro.dbt.current_timestamp": {
@@ -10054,7 +10027,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.707132,
+            "created_at": 1708330298.6857924,
             "supported_languages": null
         },
         "macro.dbt.default__current_timestamp": {
@@ -10076,7 +10049,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7072425,
+            "created_at": 1708330298.6859424,
             "supported_languages": null
         },
         "macro.dbt.snapshot_get_time": {
@@ -10100,7 +10073,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.707349,
+            "created_at": 1708330298.6860795,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_get_time": {
@@ -10124,7 +10097,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7074232,
+            "created_at": 1708330298.6861804,
             "supported_languages": null
         },
         "macro.dbt.current_timestamp_backcompat": {
@@ -10148,7 +10121,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7075512,
+            "created_at": 1708330298.686342,
             "supported_languages": null
         },
         "macro.dbt.default__current_timestamp_backcompat": {
@@ -10170,7 +10143,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7076056,
+            "created_at": 1708330298.686416,
             "supported_languages": null
         },
         "macro.dbt.current_timestamp_in_utc_backcompat": {
@@ -10194,7 +10167,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7077236,
+            "created_at": 1708330298.686591,
             "supported_languages": null
         },
         "macro.dbt.default__current_timestamp_in_utc_backcompat": {
@@ -10219,7 +10192,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7078428,
+            "created_at": 1708330298.686751,
             "supported_languages": null
         },
         "macro.dbt.create_schema": {
@@ -10243,7 +10216,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7081206,
+            "created_at": 1708330298.6871312,
             "supported_languages": null
         },
         "macro.dbt.default__create_schema": {
@@ -10267,7 +10240,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.708255,
+            "created_at": 1708330298.6873097,
             "supported_languages": null
         },
         "macro.dbt.drop_schema": {
@@ -10291,7 +10264,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7083747,
+            "created_at": 1708330298.6874635,
             "supported_languages": null
         },
         "macro.dbt.default__drop_schema": {
@@ -10315,7 +10288,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7085874,
+            "created_at": 1708330298.687781,
             "supported_languages": null
         },
         "macro.dbt.alter_column_comment": {
@@ -10339,7 +10312,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7091265,
+            "created_at": 1708330298.6884515,
             "supported_languages": null
         },
         "macro.dbt.default__alter_column_comment": {
@@ -10361,7 +10334,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7092514,
+            "created_at": 1708330298.6886406,
             "supported_languages": null
         },
         "macro.dbt.alter_relation_comment": {
@@ -10385,7 +10358,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7093942,
+            "created_at": 1708330298.6888337,
             "supported_languages": null
         },
         "macro.dbt.default__alter_relation_comment": {
@@ -10407,7 +10380,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7095273,
+            "created_at": 1708330298.689002,
             "supported_languages": null
         },
         "macro.dbt.persist_docs": {
@@ -10431,7 +10404,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.709718,
+            "created_at": 1708330298.6893237,
             "supported_languages": null
         },
         "macro.dbt.default__persist_docs": {
@@ -10457,7 +10430,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7100742,
+            "created_at": 1708330298.6899436,
             "supported_languages": null
         },
         "macro.dbt.get_show_sql": {
@@ -10481,7 +10454,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7104666,
+            "created_at": 1708330298.6905391,
             "supported_languages": null
         },
         "macro.dbt.get_limit_subquery_sql": {
@@ -10505,7 +10478,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7106028,
+            "created_at": 1708330298.690736,
             "supported_languages": null
         },
         "macro.dbt.default__get_limit_subquery_sql": {
@@ -10527,7 +10500,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.710701,
+            "created_at": 1708330298.6908708,
             "supported_languages": null
         },
         "macro.dbt.get_catalog_relations": {
@@ -10551,7 +10524,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7128594,
+            "created_at": 1708330298.6937242,
             "supported_languages": null
         },
         "macro.dbt.default__get_catalog_relations": {
@@ -10573,7 +10546,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7130463,
+            "created_at": 1708330298.6939764,
             "supported_languages": null
         },
         "macro.dbt.get_catalog": {
@@ -10597,7 +10570,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.713192,
+            "created_at": 1708330298.6941724,
             "supported_languages": null
         },
         "macro.dbt.default__get_catalog": {
@@ -10619,7 +10592,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.713377,
+            "created_at": 1708330298.6944196,
             "supported_languages": null
         },
         "macro.dbt.information_schema_name": {
@@ -10643,7 +10616,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.713514,
+            "created_at": 1708330298.6946058,
             "supported_languages": null
         },
         "macro.dbt.default__information_schema_name": {
@@ -10665,7 +10638,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7136285,
+            "created_at": 1708330298.6947546,
             "supported_languages": null
         },
         "macro.dbt.list_schemas": {
@@ -10689,7 +10662,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.713758,
+            "created_at": 1708330298.6949258,
             "supported_languages": null
         },
         "macro.dbt.default__list_schemas": {
@@ -10714,7 +10687,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7139344,
+            "created_at": 1708330298.6951747,
             "supported_languages": null
         },
         "macro.dbt.check_schema_exists": {
@@ -10738,7 +10711,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.71408,
+            "created_at": 1708330298.695369,
             "supported_languages": null
         },
         "macro.dbt.default__check_schema_exists": {
@@ -10763,7 +10736,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7143009,
+            "created_at": 1708330298.6956708,
             "supported_languages": null
         },
         "macro.dbt.list_relations_without_caching": {
@@ -10787,7 +10760,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7144334,
+            "created_at": 1708330298.69585,
             "supported_languages": null
         },
         "macro.dbt.default__list_relations_without_caching": {
@@ -10809,7 +10782,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7145672,
+            "created_at": 1708330298.6960087,
             "supported_languages": null
         },
         "macro.dbt.get_relations": {
@@ -10833,7 +10806,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7146888,
+            "created_at": 1708330298.6961653,
             "supported_languages": null
         },
         "macro.dbt.default__get_relations": {
@@ -10855,7 +10828,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7148013,
+            "created_at": 1708330298.6963146,
             "supported_languages": null
         },
         "macro.dbt.get_relation_last_modified": {
@@ -10879,7 +10852,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.714948,
+            "created_at": 1708330298.6965284,
             "supported_languages": null
         },
         "macro.dbt.default__get_relation_last_modified": {
@@ -10901,7 +10874,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7150745,
+            "created_at": 1708330298.6967025,
             "supported_languages": null
         },
         "macro.dbt.validate_sql": {
@@ -10925,7 +10898,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7152803,
+            "created_at": 1708330298.6969883,
             "supported_languages": null
         },
         "macro.dbt.default__validate_sql": {
@@ -10949,7 +10922,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.715514,
+            "created_at": 1708330298.6973152,
             "supported_languages": null
         },
         "macro.dbt.make_intermediate_relation": {
@@ -10973,7 +10946,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7170892,
+            "created_at": 1708330298.6996481,
             "supported_languages": null
         },
         "macro.dbt.default__make_intermediate_relation": {
@@ -10997,7 +10970,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7172108,
+            "created_at": 1708330298.6998343,
             "supported_languages": null
         },
         "macro.dbt.make_temp_relation": {
@@ -11021,7 +10994,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7173676,
+            "created_at": 1708330298.7000697,
             "supported_languages": null
         },
         "macro.dbt.default__make_temp_relation": {
@@ -11043,7 +11016,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7175884,
+            "created_at": 1708330298.700396,
             "supported_languages": null
         },
         "macro.dbt.make_backup_relation": {
@@ -11067,7 +11040,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7177603,
+            "created_at": 1708330298.7006702,
             "supported_languages": null
         },
         "macro.dbt.default__make_backup_relation": {
@@ -11089,7 +11062,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.717989,
+            "created_at": 1708330298.7010062,
             "supported_languages": null
         },
         "macro.dbt.truncate_relation": {
@@ -11113,7 +11086,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7181194,
+            "created_at": 1708330298.7011907,
             "supported_languages": null
         },
         "macro.dbt.default__truncate_relation": {
@@ -11137,7 +11110,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7182357,
+            "created_at": 1708330298.701359,
             "supported_languages": null
         },
         "macro.dbt.get_or_create_relation": {
@@ -11161,7 +11134,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7184162,
+            "created_at": 1708330298.701628,
             "supported_languages": null
         },
         "macro.dbt.default__get_or_create_relation": {
@@ -11183,7 +11156,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7188413,
+            "created_at": 1708330298.7022717,
             "supported_languages": null
         },
         "macro.dbt.load_cached_relation": {
@@ -11205,7 +11178,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.71901,
+            "created_at": 1708330298.7025523,
             "supported_languages": null
         },
         "macro.dbt.load_relation": {
@@ -11229,7 +11202,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7191117,
+            "created_at": 1708330298.7026973,
             "supported_languages": null
         },
         "macro.dbt.get_create_index_sql": {
@@ -11253,7 +11226,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7197466,
+            "created_at": 1708330298.703569,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_index_sql": {
@@ -11275,7 +11248,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7198482,
+            "created_at": 1708330298.7037008,
             "supported_languages": null
         },
         "macro.dbt.create_indexes": {
@@ -11299,7 +11272,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7199607,
+            "created_at": 1708330298.703851,
             "supported_languages": null
         },
         "macro.dbt.default__create_indexes": {
@@ -11324,7 +11297,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7202456,
+            "created_at": 1708330298.7042568,
             "supported_languages": null
         },
         "macro.dbt.get_drop_index_sql": {
@@ -11348,7 +11321,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7203767,
+            "created_at": 1708330298.7044408,
             "supported_languages": null
         },
         "macro.dbt.default__get_drop_index_sql": {
@@ -11370,7 +11343,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.720484,
+            "created_at": 1708330298.704594,
             "supported_languages": null
         },
         "macro.dbt.get_show_indexes_sql": {
@@ -11394,7 +11367,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7205935,
+            "created_at": 1708330298.7047448,
             "supported_languages": null
         },
         "macro.dbt.default__get_show_indexes_sql": {
@@ -11416,7 +11389,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7206821,
+            "created_at": 1708330298.7048671,
             "supported_languages": null
         },
         "macro.dbt.collect_freshness": {
@@ -11440,7 +11413,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7209866,
+            "created_at": 1708330298.7052772,
             "supported_languages": null
         },
         "macro.dbt.default__collect_freshness": {
@@ -11465,7 +11438,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7212818,
+            "created_at": 1708330298.7057054,
             "supported_languages": null
         },
         "macro.dbt.copy_grants": {
@@ -11489,7 +11462,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7226195,
+            "created_at": 1708330298.7075596,
             "supported_languages": null
         },
         "macro.dbt.default__copy_grants": {
@@ -11511,7 +11484,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7227015,
+            "created_at": 1708330298.70769,
             "supported_languages": null
         },
         "macro.dbt.support_multiple_grantees_per_dcl_statement": {
@@ -11535,7 +11508,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7228231,
+            "created_at": 1708330298.7078502,
             "supported_languages": null
         },
         "macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
@@ -11557,7 +11530,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7229025,
+            "created_at": 1708330298.7079563,
             "supported_languages": null
         },
         "macro.dbt.should_revoke": {
@@ -11581,7 +11554,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7233257,
+            "created_at": 1708330298.708632,
             "supported_languages": null
         },
         "macro.dbt.get_show_grant_sql": {
@@ -11605,7 +11578,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7234676,
+            "created_at": 1708330298.7088225,
             "supported_languages": null
         },
         "macro.dbt.default__get_show_grant_sql": {
@@ -11627,7 +11600,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7235425,
+            "created_at": 1708330298.7089264,
             "supported_languages": null
         },
         "macro.dbt.get_grant_sql": {
@@ -11651,7 +11624,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7237387,
+            "created_at": 1708330298.7091422,
             "supported_languages": null
         },
         "macro.dbt.default__get_grant_sql": {
@@ -11673,7 +11646,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.72389,
+            "created_at": 1708330298.7094028,
             "supported_languages": null
         },
         "macro.dbt.get_revoke_sql": {
@@ -11697,7 +11670,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7240582,
+            "created_at": 1708330298.7096798,
             "supported_languages": null
         },
         "macro.dbt.default__get_revoke_sql": {
@@ -11719,7 +11692,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.724196,
+            "created_at": 1708330298.7098777,
             "supported_languages": null
         },
         "macro.dbt.get_dcl_statement_list": {
@@ -11743,7 +11716,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7243588,
+            "created_at": 1708330298.7101038,
             "supported_languages": null
         },
         "macro.dbt.default__get_dcl_statement_list": {
@@ -11767,7 +11740,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7248604,
+            "created_at": 1708330298.7108228,
             "supported_languages": null
         },
         "macro.dbt.call_dcl_statements": {
@@ -11791,7 +11764,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7250001,
+            "created_at": 1708330298.7110174,
             "supported_languages": null
         },
         "macro.dbt.default__call_dcl_statements": {
@@ -11815,7 +11788,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7251859,
+            "created_at": 1708330298.7112856,
             "supported_languages": null
         },
         "macro.dbt.apply_grants": {
@@ -11839,7 +11812,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7253506,
+            "created_at": 1708330298.7115273,
             "supported_languages": null
         },
         "macro.dbt.default__apply_grants": {
@@ -11866,7 +11839,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7261891,
+            "created_at": 1708330298.7127564,
             "supported_languages": null
         },
         "macro.dbt.get_columns_in_relation": {
@@ -11890,7 +11863,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7279563,
+            "created_at": 1708330298.715107,
             "supported_languages": null
         },
         "macro.dbt.default__get_columns_in_relation": {
@@ -11912,7 +11885,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7280762,
+            "created_at": 1708330298.715303,
             "supported_languages": null
         },
         "macro.dbt.sql_convert_columns_in_relation": {
@@ -11934,7 +11907,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7283032,
+            "created_at": 1708330298.7156436,
             "supported_languages": null
         },
         "macro.dbt.get_empty_subquery_sql": {
@@ -11958,7 +11931,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7284687,
+            "created_at": 1708330298.7158732,
             "supported_languages": null
         },
         "macro.dbt.default__get_empty_subquery_sql": {
@@ -11980,7 +11953,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7286265,
+            "created_at": 1708330298.7160895,
             "supported_languages": null
         },
         "macro.dbt.get_empty_schema_sql": {
@@ -12004,7 +11977,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7287583,
+            "created_at": 1708330298.716269,
             "supported_languages": null
         },
         "macro.dbt.default__get_empty_schema_sql": {
@@ -12026,7 +11999,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7296267,
+            "created_at": 1708330298.7174451,
             "supported_languages": null
         },
         "macro.dbt.get_column_schema_from_query": {
@@ -12050,7 +12023,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7298827,
+            "created_at": 1708330298.7178178,
             "supported_languages": null
         },
         "macro.dbt.get_columns_in_query": {
@@ -12074,7 +12047,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7300174,
+            "created_at": 1708330298.7180011,
             "supported_languages": null
         },
         "macro.dbt.default__get_columns_in_query": {
@@ -12099,7 +12072,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7302794,
+            "created_at": 1708330298.7183414,
             "supported_languages": null
         },
         "macro.dbt.alter_column_type": {
@@ -12123,7 +12096,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7304437,
+            "created_at": 1708330298.7185905,
             "supported_languages": null
         },
         "macro.dbt.default__alter_column_type": {
@@ -12147,7 +12120,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.730887,
+            "created_at": 1708330298.7191694,
             "supported_languages": null
         },
         "macro.dbt.alter_relation_add_remove_columns": {
@@ -12171,7 +12144,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7310727,
+            "created_at": 1708330298.7194304,
             "supported_languages": null
         },
         "macro.dbt.default__alter_relation_add_remove_columns": {
@@ -12195,7 +12168,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.75984,
+            "created_at": 1708330298.753678,
             "supported_languages": null
         },
         "macro.dbt.test_unique": {
@@ -12219,7 +12192,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7602737,
+            "created_at": 1708330298.754263,
             "supported_languages": null
         },
         "macro.dbt.test_not_null": {
@@ -12243,7 +12216,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7604444,
+            "created_at": 1708330298.7545114,
             "supported_languages": null
         },
         "macro.dbt.test_accepted_values": {
@@ -12267,7 +12240,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7606668,
+            "created_at": 1708330298.7547958,
             "supported_languages": null
         },
         "macro.dbt.test_relationships": {
@@ -12291,7 +12264,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1706145554.7608657,
+            "created_at": 1708330298.7550614,
             "supported_languages": null
         }
     },
@@ -12307,6 +12280,50 @@
         }
     },
     "exposures": {
+        "exposure.sandbox.clients": {
+            "name": "clients",
+            "resource_type": "exposure",
+            "package_name": "sandbox",
+            "path": "exposures/our_analytics.yml",
+            "original_file_path": "models/exposures/our_analytics.yml",
+            "unique_id": "exposure.sandbox.clients",
+            "fqn": [
+                "sandbox",
+                "exposures",
+                "clients"
+            ],
+            "type": "analysis",
+            "owner": {
+                "email": "dbtmetabase@example.com",
+                "name": "dbtmetabase"
+            },
+            "description": "### Visualization: Table\n\nNo description provided in Metabase\n\n#### Metadata\n\nMetabase ID: __3__\n\nCreated On: __2024-02-19T03:48:22.030934__",
+            "label": "clients",
+            "maturity": "medium",
+            "meta": {},
+            "tags": [],
+            "config": {
+                "enabled": true
+            },
+            "unrendered_config": {},
+            "url": "http://localhost:3000/card/3",
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "model.sandbox.customers"
+                ]
+            },
+            "refs": [
+                {
+                    "name": "customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "created_at": 1708330299.1868012
+        },
         "exposure.sandbox.customers": {
             "name": "customers",
             "resource_type": "exposure",
@@ -12324,7 +12341,7 @@
                 "email": "dbtmetabase@example.com",
                 "name": "dbtmetabase"
             },
-            "description": "### Visualization: Line\n\nCustomers test\n\n#### Metadata\n\nMetabase ID: __1__\n\nCreated On: __2024-01-24T05:33:25.647584__",
+            "description": "### Visualization: Line\n\nCustomers test\n\n#### Metadata\n\nMetabase ID: __1__\n\nCreated On: __2024-02-19T03:42:12.127181__",
             "label": "Customers",
             "maturity": "medium",
             "meta": {},
@@ -12349,7 +12366,7 @@
             ],
             "sources": [],
             "metrics": [],
-            "created_at": 1706145555.0796468
+            "created_at": 1708330299.1877074
         },
         "exposure.sandbox.orders": {
             "name": "orders",
@@ -12368,7 +12385,7 @@
                 "email": "dbtmetabase@example.com",
                 "name": "dbtmetabase"
             },
-            "description": "### Visualization: Table\n\nNo description provided in Metabase\n\n#### Metadata\n\nMetabase ID: __2__\n\nCreated On: __2024-01-24T05:58:57.73953__",
+            "description": "### Visualization: Table\n\nNo description provided in Metabase\n\n#### Metadata\n\nMetabase ID: __2__\n\nCreated On: __2024-02-19T03:48:08.251792__",
             "label": "Orders",
             "maturity": "medium",
             "meta": {},
@@ -12393,51 +12410,7 @@
             ],
             "sources": [],
             "metrics": [],
-            "created_at": 1706145555.0805569
-        },
-        "exposure.sandbox.stg_payments": {
-            "name": "stg_payments",
-            "resource_type": "exposure",
-            "package_name": "sandbox",
-            "path": "exposures/our_analytics.yml",
-            "original_file_path": "models/exposures/our_analytics.yml",
-            "unique_id": "exposure.sandbox.stg_payments",
-            "fqn": [
-                "sandbox",
-                "exposures",
-                "stg_payments"
-            ],
-            "type": "analysis",
-            "owner": {
-                "email": "dbtmetabase@example.com",
-                "name": "dbtmetabase"
-            },
-            "description": "### Visualization: Table\n\nNo description provided in Metabase\n\n#### Metadata\n\nMetabase ID: __3__\n\nCreated On: __2024-01-24T05:59:13.224303__",
-            "label": "Stg Payments",
-            "maturity": "medium",
-            "meta": {},
-            "tags": [],
-            "config": {
-                "enabled": true
-            },
-            "unrendered_config": {},
-            "url": "http://localhost:3000/card/3",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "model.sandbox.stg_payments"
-                ]
-            },
-            "refs": [
-                {
-                    "name": "stg_payments",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "created_at": 1706145555.0812972
+            "created_at": 1708330299.1887019
         }
     },
     "metrics": {},
@@ -12450,9 +12423,14 @@
             "model.sandbox.stg_orders",
             "model.sandbox.stg_payments"
         ],
-        "model.sandbox.orders": [
-            "model.sandbox.stg_orders",
-            "model.sandbox.stg_payments"
+        "seed.sandbox.raw_customers": [],
+        "seed.sandbox.raw_orders": [],
+        "seed.sandbox.raw_payments": [],
+        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [
+            "model.sandbox.customers"
+        ],
+        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [
+            "model.sandbox.customers"
         ],
         "model.sandbox.stg_customers": [
             "seed.sandbox.raw_customers"
@@ -12463,14 +12441,33 @@
         "model.sandbox.stg_orders": [
             "seed.sandbox.raw_orders"
         ],
-        "seed.sandbox.raw_customers": [],
-        "seed.sandbox.raw_orders": [],
-        "seed.sandbox.raw_payments": [],
-        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [
-            "model.sandbox.customers"
+        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [
+            "model.sandbox.stg_customers"
         ],
-        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [
-            "model.sandbox.customers"
+        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [
+            "model.sandbox.stg_customers"
+        ],
+        "test.sandbox.unique_stg_payments_payment_id.3744510712": [
+            "model.sandbox.stg_payments"
+        ],
+        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [
+            "model.sandbox.stg_payments"
+        ],
+        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [
+            "model.sandbox.stg_payments"
+        ],
+        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [
+            "model.sandbox.stg_orders"
+        ],
+        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [
+            "model.sandbox.stg_orders"
+        ],
+        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [
+            "model.sandbox.stg_orders"
+        ],
+        "model.sandbox.orders": [
+            "model.sandbox.stg_orders",
+            "model.sandbox.stg_payments"
         ],
         "test.sandbox.unique_orders_order_id.fed79b3a6e": [
             "model.sandbox.orders"
@@ -12479,10 +12476,6 @@
             "model.sandbox.orders"
         ],
         "test.sandbox.not_null_orders_customer_id.c5f02694af": [
-            "model.sandbox.orders"
-        ],
-        "test.sandbox.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": [
-            "model.sandbox.customers",
             "model.sandbox.orders"
         ],
         "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [
@@ -12503,67 +12496,40 @@
         "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": [
             "model.sandbox.orders"
         ],
-        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [
-            "model.sandbox.stg_customers"
-        ],
-        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [
-            "model.sandbox.stg_customers"
-        ],
-        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [
-            "model.sandbox.stg_orders"
-        ],
-        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [
-            "model.sandbox.stg_orders"
-        ],
-        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [
-            "model.sandbox.stg_orders"
-        ],
-        "test.sandbox.unique_stg_payments_payment_id.3744510712": [
-            "model.sandbox.stg_payments"
-        ],
-        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [
-            "model.sandbox.stg_payments"
-        ],
-        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [
-            "model.sandbox.stg_payments"
+        "exposure.sandbox.clients": [
+            "model.sandbox.customers"
         ],
         "exposure.sandbox.customers": [
             "model.sandbox.customers"
         ],
         "exposure.sandbox.orders": [
             "model.sandbox.orders"
-        ],
-        "exposure.sandbox.stg_payments": [
-            "model.sandbox.stg_payments"
         ]
     },
     "child_map": {
         "model.sandbox.customers": [
+            "exposure.sandbox.clients",
             "exposure.sandbox.customers",
             "test.sandbox.not_null_customers_customer_id.5c9bf9911d",
-            "test.sandbox.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
             "test.sandbox.unique_customers_customer_id.c5af1ff4b1"
         ],
-        "model.sandbox.orders": [
-            "exposure.sandbox.orders",
-            "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
-            "test.sandbox.not_null_orders_amount.106140f9fd",
-            "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49",
-            "test.sandbox.not_null_orders_coupon_amount.ab90c90625",
-            "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59",
-            "test.sandbox.not_null_orders_customer_id.c5f02694af",
-            "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a",
-            "test.sandbox.not_null_orders_order_id.cf6c17daed",
-            "test.sandbox.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
-            "test.sandbox.unique_orders_order_id.fed79b3a6e"
+        "seed.sandbox.raw_customers": [
+            "model.sandbox.stg_customers"
         ],
+        "seed.sandbox.raw_orders": [
+            "model.sandbox.stg_orders"
+        ],
+        "seed.sandbox.raw_payments": [
+            "model.sandbox.stg_payments"
+        ],
+        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [],
+        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [],
         "model.sandbox.stg_customers": [
             "model.sandbox.customers",
             "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa",
             "test.sandbox.unique_stg_customers_customer_id.c7614daada"
         ],
         "model.sandbox.stg_payments": [
-            "exposure.sandbox.stg_payments",
             "model.sandbox.customers",
             "model.sandbox.orders",
             "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
@@ -12577,38 +12543,38 @@
             "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64",
             "test.sandbox.unique_stg_orders_order_id.e3b841c71a"
         ],
-        "seed.sandbox.raw_customers": [
-            "model.sandbox.stg_customers"
+        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [],
+        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
+        "test.sandbox.unique_stg_payments_payment_id.3744510712": [],
+        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [],
+        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [],
+        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [],
+        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [],
+        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
+        "model.sandbox.orders": [
+            "exposure.sandbox.orders",
+            "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+            "test.sandbox.not_null_orders_amount.106140f9fd",
+            "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49",
+            "test.sandbox.not_null_orders_coupon_amount.ab90c90625",
+            "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59",
+            "test.sandbox.not_null_orders_customer_id.c5f02694af",
+            "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a",
+            "test.sandbox.not_null_orders_order_id.cf6c17daed",
+            "test.sandbox.unique_orders_order_id.fed79b3a6e"
         ],
-        "seed.sandbox.raw_orders": [
-            "model.sandbox.stg_orders"
-        ],
-        "seed.sandbox.raw_payments": [
-            "model.sandbox.stg_payments"
-        ],
-        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [],
-        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [],
         "test.sandbox.unique_orders_order_id.fed79b3a6e": [],
         "test.sandbox.not_null_orders_order_id.cf6c17daed": [],
         "test.sandbox.not_null_orders_customer_id.c5f02694af": [],
-        "test.sandbox.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": [],
         "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [],
         "test.sandbox.not_null_orders_amount.106140f9fd": [],
         "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59": [],
         "test.sandbox.not_null_orders_coupon_amount.ab90c90625": [],
         "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49": [],
         "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": [],
-        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [],
-        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
-        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [],
-        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [],
-        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
-        "test.sandbox.unique_stg_payments_payment_id.3744510712": [],
-        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [],
-        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [],
+        "exposure.sandbox.clients": [],
         "exposure.sandbox.customers": [],
-        "exposure.sandbox.orders": [],
-        "exposure.sandbox.stg_payments": []
+        "exposure.sandbox.orders": []
     },
     "group_map": {},
     "saved_queries": {},


### PR DESCRIPTION
- Support column [constraints](https://docs.getdbt.com/reference/resource-properties/constraints) of types `primary_key` and `foreign_key`
- Foreign key precedence is now (lowest to highest): relationship test, constraint, meta fields
- Fixes #230