### PR TITLE
Handle uppercase references from Metabase GUI derived queries

### DIFF
--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -214,7 +214,9 @@ class ExposuresMixin(metaclass=ABCMeta):
                     )
                 elif query_source in ctx.table_names:
                     # Normal question
-                    source_table = ctx.table_names.get(query_source).lower()
+                    source_table = ctx.table_names.get(query_source)
+                    if source_table:
+                        source_table = source_table.lower()
                     _logger.info("Extracted model '%s' from card", source_table)
                     depends.add(source_table)
 

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -214,7 +214,7 @@ class ExposuresMixin(metaclass=ABCMeta):
                     )
                 elif query_source in ctx.table_names:
                     # Normal question
-                    source_table = ctx.table_names.get(query_source)
+                    source_table = ctx.table_names.get(query_source).lower()
                     _logger.info("Extracted model '%s' from card", source_table)
                     depends.add(source_table)
 
@@ -237,6 +237,7 @@ class ExposuresMixin(metaclass=ABCMeta):
                     # Joined model parsed
                     joined_table = ctx.table_names.get(join_source)
                     if joined_table:
+                        joined_table = joined_table.lower()
                         _logger.info("Extracted model '%s' from join", joined_table)
                         depends.add(joined_table)
 

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -217,8 +217,8 @@ class ExposuresMixin(metaclass=ABCMeta):
                     source_table = ctx.table_names.get(query_source)
                     if source_table:
                         source_table = source_table.lower()
-                    _logger.info("Extracted model '%s' from card", source_table)
-                    depends.add(source_table)
+                        _logger.info("Extracted model '%s' from card", source_table)
+                        depends.add(source_table)
 
                 # Find models exposed through joins
                 for join in query.get("query", {}).get("joins", []):

--- a/tests/fixtures/api/table.json
+++ b/tests/fixtures/api/table.json
@@ -52,7 +52,7 @@
             "points_of_interest": null
         },
         "show_in_getting_started": false,
-        "name": "customers",
+        "name": "CUSTOMERS",
         "caveats": null,
         "updated_at": "2021-07-21T07:30:35.159586Z",
         "entity_name": null,


### PR DESCRIPTION
Relates to discussion: https://github.com/gouline/dbt-metabase/discussions/241

Some data warehouses, such as snowflake, store their object names (database, schema, table, columns) in uppercase ([ref](https://community.snowflake.com/s/article/faq-when-i-retrieve-database-schema-table-or-column-names-why-does-snowflake-display-them-in-uppercase)). 

This means that metabase questions derived from the visual editor (GUI) need to have their sources lowercased in order to match with dbt's models and nodes. We already do this for SQL native queries (refs: [1](https://github.com/gouline/dbt-metabase/blob/master/dbtmetabase/_exposures.py#L250), [2](https://github.com/gouline/dbt-metabase/blob/master/dbtmetabase/_exposures.py#L255)) so this is just a continuation of that logic.

## Update

If `table.json` fixture is modified to contain uppercase table names, the exposure tests fail before this change is applied and pass after it is applied.