### PR TITLE
Add flag to exposures for excluding all unverified collection items

### DIFF
--- a/dbtmetabase/__main__.py
+++ b/dbtmetabase/__main__.py
@@ -360,11 +360,11 @@ def models(
     help="Include personal Metabase collections.",
 )
 @click.option(
-    "--exclude-unverified-cards",
-    envvar="EXCLUDE_UNVERIFIED_CARDS",
+    "--exclude-unverified",
+    envvar="EXCLUDE_UNVERIFIED",
     show_envvar=True,
     is_flag=True,
-    help="Exclude cards that have not been verified.",
+    help="Exclude items that have not been verified. Only applies to entity types that support verification.",
 )
 def exposures(
     output_path: str,
@@ -372,7 +372,7 @@ def exposures(
     include_collections: Optional[Sequence[str]],
     exclude_collections: Optional[Sequence[str]],
     allow_personal_collections: bool,
-    exclude_unverified_cards: bool,
+    exclude_unverified: bool,
     core: DbtMetabase,
 ):
     core.extract_exposures(
@@ -383,7 +383,7 @@ def exposures(
             exclude=exclude_collections,
         ),
         allow_personal_collections=allow_personal_collections,
-        exclude_unverified_cards=exclude_unverified_cards,
+        exclude_unverified=exclude_unverified,
     )
 
 

--- a/dbtmetabase/__main__.py
+++ b/dbtmetabase/__main__.py
@@ -360,11 +360,11 @@ def models(
     help="Include personal Metabase collections.",
 )
 @click.option(
-    "--exclude-unverified",
-    envvar="EXCLUDE_UNVERIFIED",
+    "--exclude-unverified-cards",
+    envvar="EXCLUDE_UNVERIFIED_CARDS",
     show_envvar=True,
     is_flag=True,
-    help="Exclude collection items that have not been verified.",
+    help="Exclude cards that have not been verified.",
 )
 def exposures(
     output_path: str,
@@ -372,7 +372,7 @@ def exposures(
     include_collections: Optional[Sequence[str]],
     exclude_collections: Optional[Sequence[str]],
     allow_personal_collections: bool,
-    exclude_unverified: bool,
+    exclude_unverified_cards: bool,
     core: DbtMetabase,
 ):
     core.extract_exposures(
@@ -383,7 +383,7 @@ def exposures(
             exclude=exclude_collections,
         ),
         allow_personal_collections=allow_personal_collections,
-        exclude_unverified=exclude_unverified,
+        exclude_unverified_cards=exclude_unverified_cards,
     )
 
 

--- a/dbtmetabase/__main__.py
+++ b/dbtmetabase/__main__.py
@@ -359,12 +359,20 @@ def models(
     is_flag=True,
     help="Include personal Metabase collections.",
 )
+@click.option(
+    "--exclude-unverified",
+    envvar="EXCLUDE_UNVERIFIED",
+    show_envvar=True,
+    is_flag=True,
+    help="Exclude collection items that have not been verified.",
+)
 def exposures(
     output_path: str,
     output_grouping: Optional[str],
     include_collections: Optional[Sequence[str]],
     exclude_collections: Optional[Sequence[str]],
     allow_personal_collections: bool,
+    exclude_unverified: bool,
     core: DbtMetabase,
 ):
     core.extract_exposures(
@@ -375,6 +383,7 @@ def exposures(
             exclude=exclude_collections,
         ),
         allow_personal_collections=allow_personal_collections,
+        exclude_unverified=exclude_unverified,
     )
 
 

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -93,8 +93,8 @@ class ExposuresMixin(metaclass=ABCMeta):
             ):
                 if (
                     exclude_unverified_cards
+                    and item["model"] == "card"
                     and item.get("moderated_status") != "verified"
-                    and item.get("model") == "card"
                 ):
                     _logger.debug("Skipping unverified card '%s'", item["name"])
                     continue

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -46,6 +46,7 @@ class ExposuresMixin(metaclass=ABCMeta):
         output_grouping: Optional[str] = None,
         collection_filter: Optional[Filter] = None,
         allow_personal_collections: bool = False,
+        exclude_unverified: bool = False,
     ) -> Iterable[Mapping]:
         """Extract dbt exposures from Metabase.
 
@@ -54,6 +55,7 @@ class ExposuresMixin(metaclass=ABCMeta):
             output_grouping (Optional[str], optional): Grouping for output YAML files, supported values: "collection" (by collection slug) or "type" (by entity type). Defaults to None.
             collection_filter (Optional[Filter], optional): Filter Metabase collections. Defaults to None.
             allow_personal_collections (bool, optional): Allow personal Metabase collections. Defaults to False.
+            exlcude_unverified (bool, optional): Exclude unverified models. Defaults to False.
 
         Returns:
             Iterable[Mapping]: List of parsed exposures.
@@ -88,6 +90,7 @@ class ExposuresMixin(metaclass=ABCMeta):
             for item in self.metabase.get_collection_items(
                 uid=collection["id"],
                 models=("card", "dashboard"),
+                exclude_unverified=exclude_unverified,
             ):
                 depends = set()
                 native_query = ""

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -46,7 +46,7 @@ class ExposuresMixin(metaclass=ABCMeta):
         output_grouping: Optional[str] = None,
         collection_filter: Optional[Filter] = None,
         allow_personal_collections: bool = False,
-        exclude_unverified: bool = False,
+        exclude_unverified_cards: bool = False,
     ) -> Iterable[Mapping]:
         """Extract dbt exposures from Metabase.
 
@@ -55,7 +55,7 @@ class ExposuresMixin(metaclass=ABCMeta):
             output_grouping (Optional[str], optional): Grouping for output YAML files, supported values: "collection" (by collection slug) or "type" (by entity type). Defaults to None.
             collection_filter (Optional[Filter], optional): Filter Metabase collections. Defaults to None.
             allow_personal_collections (bool, optional): Allow personal Metabase collections. Defaults to False.
-            exlcude_unverified (bool, optional): Exclude unverified models. Defaults to False.
+            exclude_unverified_cards (bool, optional): Exclude unverified cards. Defaults to False.
 
         Returns:
             Iterable[Mapping]: List of parsed exposures.
@@ -91,8 +91,12 @@ class ExposuresMixin(metaclass=ABCMeta):
                 uid=collection["id"],
                 models=("card", "dashboard"),
             ):
-                if exclude_unverified and item.get("moderated_status") != "verified":
-                    _logger.debug("Skipping unverified item '%s'", item["id"])
+                if (
+                    exclude_unverified_cards
+                    and item.get("moderated_status") != "verified"
+                    and item.get("model") == "card"
+                ):
+                    _logger.debug("Skipping unverified card '%s'", item["name"])
                     continue
                 depends = set()
                 native_query = ""

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -90,8 +90,10 @@ class ExposuresMixin(metaclass=ABCMeta):
             for item in self.metabase.get_collection_items(
                 uid=collection["id"],
                 models=("card", "dashboard"),
-                exclude_unverified=exclude_unverified,
             ):
+                if exclude_unverified and item.get("moderated_status") != "verified":
+                    _logger.debug("Skipping unverified item '%s'", item["id"])
+                    continue
                 depends = set()
                 native_query = ""
                 header = ""

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -98,6 +98,7 @@ class ExposuresMixin(metaclass=ABCMeta):
                 ):
                     _logger.debug("Skipping unverified card '%s'", item["name"])
                     continue
+
                 depends = set()
                 native_query = ""
                 header = ""

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -46,7 +46,7 @@ class ExposuresMixin(metaclass=ABCMeta):
         output_grouping: Optional[str] = None,
         collection_filter: Optional[Filter] = None,
         allow_personal_collections: bool = False,
-        exclude_unverified_cards: bool = False,
+        exclude_unverified: bool = False,
     ) -> Iterable[Mapping]:
         """Extract dbt exposures from Metabase.
 
@@ -55,7 +55,7 @@ class ExposuresMixin(metaclass=ABCMeta):
             output_grouping (Optional[str], optional): Grouping for output YAML files, supported values: "collection" (by collection slug) or "type" (by entity type). Defaults to None.
             collection_filter (Optional[Filter], optional): Filter Metabase collections. Defaults to None.
             allow_personal_collections (bool, optional): Allow personal Metabase collections. Defaults to False.
-            exclude_unverified_cards (bool, optional): Exclude unverified cards. Defaults to False.
+            exclude_unverified (bool, optional): Exclude items that have not been verified. Only applies to entity types that support verification. Defaults to False.
 
         Returns:
             Iterable[Mapping]: List of parsed exposures.
@@ -92,7 +92,7 @@ class ExposuresMixin(metaclass=ABCMeta):
                 models=("card", "dashboard"),
             ):
                 if (
-                    exclude_unverified_cards
+                    exclude_unverified
                     and item["model"] == "card"
                     and item.get("moderated_status") != "verified"
                 ):

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -131,6 +131,7 @@ class Metabase:
         self,
         uid: str,
         models: Sequence[str],
+        exclude_unverified: bool = False,
     ) -> Sequence[Mapping]:
         """Retrieves collection items of specific types (e.g. card, dashboard, collection)."""
         results = list(
@@ -140,6 +141,16 @@ class Metabase:
                 params={"models": models},
             )
         )
+        if exclude_unverified:
+            verified_results = list(
+                self._api(
+                    method="get",
+                    path=f"/api/search/",
+                    params={"models": models, "verified": True},
+                )
+            )
+            verified_ids = [y['id'] for y in verified_results]
+            results = [x for x in results if x['id'] in verified_ids]
         results = list(filter(lambda x: x["model"] in models, results))
         return results
 

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -131,7 +131,6 @@ class Metabase:
         self,
         uid: str,
         models: Sequence[str],
-        exclude_unverified: bool = False,
     ) -> Sequence[Mapping]:
         """Retrieves collection items of specific types (e.g. card, dashboard, collection)."""
         results = list(
@@ -141,16 +140,6 @@ class Metabase:
                 params={"models": models},
             )
         )
-        if exclude_unverified:
-            verified_results = list(
-                self._api(
-                    method="get",
-                    path=f"/api/search/",
-                    params={"models": models, "verified": True},
-                )
-            )
-            verified_ids = [y['id'] for y in verified_results]
-            results = [x for x in results if x['id'] in verified_ids]
         results = list(filter(lambda x: x["model"] in models, results))
         return results
 


### PR DESCRIPTION
This PR introduces the ability to add an `--exclude-unverified-cards` flag to the `exposures` command in order to weed out exposures from cards that were not verified through metabase.

Note: I tried but could not figure out how to implement a unit test for this.