### PR TITLE
Fix Dashboard Exposures Issue

### DIFF
--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -126,7 +126,7 @@ class ExposuresMixin(metaclass=ABCMeta):
                         continue
 
                     entity = dashboard_entity
-                    cards = entity.get("dashcards", [])
+                    cards = entity.get("dashcards", entity.get("ordered_cards", []))
                     if not cards:
                         continue
 

--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -126,7 +126,7 @@ class ExposuresMixin(metaclass=ABCMeta):
                         continue
 
                     entity = dashboard_entity
-                    cards = entity.get("ordered_cards", [])
+                    cards = entity.get("dashcards", [])
                     if not cards:
                         continue
 

--- a/tests/fixtures/api/dashboard/1.json
+++ b/tests/fixtures/api/dashboard/1.json
@@ -2,7 +2,7 @@
     "description": null,
     "archived": false,
     "collection_position": 1,
-    "ordered_cards": [
+    "dashcards": [
         {
             "sizeX": 18,
             "series": [],


### PR DESCRIPTION
Hello! 👋
I hope this message finds you well.

I recently encountered an issue in my environment where I wasn't able to retrieve the dashboard exposures, whereas the functionality worked seamlessly for cards. Upon investigating, I suspect that there might have been a change in the reference handling, which could be causing this discrepancy.

Here is a PR to handle the change and ensure consistent retrieval of both dashboard and card exposures!

Your feedback and review of the proposed changes would be greatly appreciated. Please feel free to reach out if you have any questions or suggestions regarding this PR ! ☀️
