### PR TITLE
Support for API keys and session ID deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Once `dbt compile` finishes, `manifest.json` can be found in the `target/` direc
 
 See [dbt documentation](https://docs.getdbt.com/docs/running-a-dbt-project/run-your-dbt-projects) for more information.
 
+## Metabase API
+
+All commands require authentication against the [Metabase API](https://www.metabase.com/docs/latest/api-documentation) using one of these methods:
+
+* API key (`--metabase-api-key`) 
+  - Strongly **recommended** for automation, see [documentation](https://www.metabase.com/docs/latest/people-and-groups/api-keys) (Metabase 49 or later).
+* Username and password (`--metabase-username` / `--metabase-password`)
+  - Fallback for older versions of Metabase and smaller instances.
+
 ## Exporting Models
 
 Let's start by defining a short sample `schema.yml` as below.
@@ -81,8 +90,7 @@ This is already enough to propagate the primary keys, foreign keys and descripti
 dbt-metabase models \
     --manifest-path target/manifest.json \
     --metabase-url https://metabase.example.com \
-    --metabase-username user@example.com \
-    --metabase-password Password123 \
+    --metabase-api-key mb_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX= \
     --metabase-database business \
     --include-schemas public
 ```
@@ -208,8 +216,7 @@ dbt-metabase allows you to extract questions and dashboards from Metabase as [db
 dbt-metabase exposures \
     --manifest-path ./target/manifest.json \
     --metabase-url https://metabase.example.com \
-    --metabase-username user@example.com \
-    --metabase-password Password123 \
+    --metabase-api-key mb_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX= \
     --output-path models/ \
     --exclude-collections "temp*"
 ```
@@ -259,8 +266,7 @@ A configuration file can be created in `~/.dbt-metabase/config.yml` for dbt-meta
 config:
     manifest_path: target/manifest.json
     metabase_url: https://metabase.example.com
-    metabase_username: user@example.com
-    metabase_password: Password123
+    metabase_api_key: mb_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=
     # Configuration specific to models command
     models:
       metabase_database: business
@@ -282,8 +288,7 @@ from dbtmetabase import DbtMetabase, Filter
 c = DbtMetabase(
     manifest_path="target/manifest.json",
     metabase_url="https://metabase.example.com",
-    metabase_username="user@example.com",
-    metabase_password="Password123",
+    metabase_api_key="mb_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=",
 )
 
 # Exporting models

--- a/dbtmetabase/__main__.py
+++ b/dbtmetabase/__main__.py
@@ -96,12 +96,20 @@ def _add_setup(func: Callable) -> Callable:
         help="Metabase URL, e.g. 'https://metabase.example.com'.",
     )
     @click.option(
+        "--metabase-api-key",
+        metavar="API_KEY",
+        envvar="METABASE_API_KEY",
+        show_envvar=True,
+        type=click.STRING,
+        help="Metabase API key (required unless providing username/password).",
+    )
+    @click.option(
         "--metabase-username",
         metavar="USERNAME",
         envvar="METABASE_USERNAME",
         show_envvar=True,
         type=click.STRING,
-        help="Metabase username (required unless providing session ID).",
+        help="Metabase username (required unless providing API key).",
     )
     @click.option(
         "--metabase-password",
@@ -109,7 +117,7 @@ def _add_setup(func: Callable) -> Callable:
         envvar="METABASE_PASSWORD",
         show_envvar=True,
         type=click.STRING,
-        help="Metabase password (required unless providing session ID).",
+        help="Metabase password (required unless providing API key).",
     )
     @click.option(
         "--metabase-session-id",
@@ -117,7 +125,8 @@ def _add_setup(func: Callable) -> Callable:
         envvar="METABASE_SESSION_ID",
         show_envvar=True,
         type=click.STRING,
-        help="Metabase session ID (alternative to username/password).",
+        help="Metabase session ID (deprecated and will be removed in future).",
+        hidden=True,
     )
     @click.option(
         "--skip-verify",
@@ -160,6 +169,7 @@ def _add_setup(func: Callable) -> Callable:
     def wrapper(
         manifest_path: str,
         metabase_url: str,
+        metabase_api_key: str,
         metabase_username: str,
         metabase_password: str,
         metabase_session_id: Optional[str],
@@ -179,6 +189,7 @@ def _add_setup(func: Callable) -> Callable:
             core=DbtMetabase(
                 manifest_path=manifest_path,
                 metabase_url=metabase_url,
+                metabase_api_key=metabase_api_key,
                 metabase_username=metabase_username,
                 metabase_password=metabase_password,
                 metabase_session_id=metabase_session_id,

--- a/dbtmetabase/core.py
+++ b/dbtmetabase/core.py
@@ -23,6 +23,7 @@ class DbtMetabase(ModelsMixin, ExposuresMixin):
         self,
         manifest_path: Union[str, Path],
         metabase_url: str,
+        metabase_api_key: Optional[str] = None,
         metabase_username: Optional[str] = None,
         metabase_password: Optional[str] = None,
         metabase_session_id: Optional[str] = None,
@@ -37,9 +38,10 @@ class DbtMetabase(ModelsMixin, ExposuresMixin):
         Args:
             manifest_path (Union[str,Path]): Path to dbt manifest.json, usually in target/ directory after compilation.
             metabase_url (str): Metabase URL, e.g. "https://metabase.example.com".
-            metabase_username (Optional[str], optional): Metabase username (required unless providing session ID). Defaults to None.
-            metabase_password (Optional[str], optional): Metabase password (required unless providing session ID). Defaults to None.
-            metabase_session_id (Optional[str], optional): Metabase session ID. Defaults to None.
+            metabase_api_key (Optional[str], optional): Metabase API key (required unless providing username/password or session ID). Defaults to None.
+            metabase_username (Optional[str], optional): Metabase username (required unless providing API key or session ID). Defaults to None.
+            metabase_password (Optional[str], optional): Metabase password (required unless providing API key or session ID). Defaults to None.
+            metabase_session_id (Optional[str], optional): Metabase session ID (deprecated and will be removed in future). Defaults to None.
             skip_verify (bool, optional): Skip TLS certificate verification (not recommended). Defaults to False.
             cert (Optional[Union[str, Tuple[str, str]]], optional): Path to a custom certificate. Defaults to None.
             http_timeout (int, optional): HTTP request timeout in secs. Defaults to 15.
@@ -52,6 +54,7 @@ class DbtMetabase(ModelsMixin, ExposuresMixin):
         )
         self._metabase = Metabase(
             url=metabase_url,
+            api_key=metabase_api_key,
             username=metabase_username,
             password=metabase_password,
             session_id=metabase_session_id,

--- a/tests/_mocks.py
+++ b/tests/_mocks.py
@@ -16,6 +16,7 @@ class MockMetabase(Metabase):
     def __init__(self, url: str):
         super().__init__(
             url=url,
+            api_key=None,
             username=None,
             password=None,
             session_id="dummy",


### PR DESCRIPTION
- Support for [API keys](https://www.metabase.com/docs/latest/people-and-groups/api-keys)
  - Thanks to @cdchan for bringing it to my attention in #248! 👏 
- As session ID was implemented in #83 to overcome the absence of proper authentication for automation and API keys finally fix that issue, session ID is hereby **deprecated** and will be removed in future once the community has had time to migrate to Metabase 49 or later