### PR TITLE
Remove mentions of discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,6 @@
 
 This project would not be here without its community, so contributions have and will always be welcome!
 
-## Questions
-
-If you have a **question** or an **idea**, please ensure it does not already exist and create a [discussion](https://github.com/gouline/dbt-metabase/discussions) under the appropriate category. This makes accepted answers and conversations available to others in the same situation.
-
 ## Issues
 
 When reporting a bug, please create an [issue](https://github.com/gouline/issues) and provide as much content as humanly possible:
@@ -20,7 +16,7 @@ When reporting a bug, please create an [issue](https://github.com/gouline/issues
 
 Code contributions must be reviewed by the maintainer in a [pull request](https://github.com/gouline/pulls). This project only has one maintainer, so please be patient if the review process takes days or weeks.
 
-Unless your change is a bug fix or an incremental addition, consider proposing your approach in a discussion or an issue first. While your contributions are appreciated, not everything is suitable for this project, and seeking feedback in advance avoids wasting your time implementing something that gets rejected.
+Unless your change is a bug fix or an incremental addition, consider proposing your approach in an issue first. While your contributions are appreciated, not everything is suitable for this project, and seeking feedback in advance avoids wasting your time implementing something that gets rejected.
 
 ### Validation
 


### PR DESCRIPTION
- Remove any mention of discussions in documentation
- People still raising issues for everything, so I'm disabling discussions to remove double-ups