### PR TITLE
Metabase 50 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,15 +63,15 @@ install: build
 .PHONY: install
 
 sandbox-up:
-	( cd sandbox && docker-compose up --build --attach app )
+	( cd sandbox && docker compose up --build --attach app )
 .PHONY: sandbox-up
 
 sandbox-down:
-	( cd sandbox && docker-compose down )
+	( cd sandbox && docker compose down )
 .PHONY: sandbox-up
 
 sandbox-models:
-	( source sandbox/.env && python3 -m dbtmetabase models \
+	( . sandbox/.env && python3 -m dbtmetabase models \
 		--manifest-path sandbox/target/manifest.json \
 		--metabase-url http://localhost:$$MB_PORT \
 		--metabase-username $$MB_USER \
@@ -86,7 +86,7 @@ sandbox-models:
 sandbox-exposures:
 	rm -rf sandbox/models/exposures
 	mkdir -p sandbox/models/exposures
-	( source sandbox/.env && python3 -m dbtmetabase exposures \
+	( . sandbox/.env && python3 -m dbtmetabase exposures \
 		--manifest-path sandbox/target/manifest.json \
 		--metabase-url http://localhost:$$MB_PORT \
 		--metabase-username $$MB_USER \
@@ -95,7 +95,7 @@ sandbox-exposures:
 		--output-grouping collection \
 		--verbose )
 	
-	( source sandbox/.env && cd sandbox && \
+	( . sandbox/.env && cd sandbox && \
 		POSTGRES_HOST=localhost \
 		POSTGRES_PORT=$$POSTGRES_PORT \
 		POSTGRES_USER=$$POSTGRES_USER \

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -185,6 +185,10 @@ class Metabase:
             if error.response.status_code == 404:
                 _logger.warning("User '%s' not found", uid)
                 return None
+            elif error.response.status_code == 400 and "internal user" in error.response.text:
+                # Since X.50.0 fetching internal user raises 400 Not able to modify the internal user
+                _logger.warning("User '%s' is internal", uid)
+                return None
             raise
 
     def update_table(self, uid: str, body: Mapping) -> Mapping:

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -185,7 +185,10 @@ class Metabase:
             if error.response.status_code == 404:
                 _logger.warning("User '%s' not found", uid)
                 return None
-            elif error.response.status_code == 400 and "internal user" in error.response.text:
+            elif (
+                error.response.status_code == 400
+                and "internal user" in error.response.text
+            ):
                 # Since X.50.0 fetching internal user raises 400 Not able to modify the internal user
                 _logger.warning("User '%s' is internal", uid)
                 return None

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@ black>=23.11.0
 isort>=5.12.0
 pylint>=3.0.2
 mypy>=1.7.1
-molot>=1.0.0,<1.1.0
-dbt-postgres>=1.7.4,<2.0.0
+molot~=1.0.0
+dbt-postgres~=1.7.16
 types-requests
 types-PyYAML

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 name: dbt-metabase-sandbox
 
 services:
@@ -22,7 +20,7 @@ services:
     restart: always
 
   metabase:
-    image: metabase/metabase:latest
+    image: metabase/metabase:v0.50.0
     environment:
       - MB_SETUP_TOKEN=${MB_SETUP_TOKEN:-}
     ports:


### PR DESCRIPTION
- Fix incompatibility with [Metabase 50](https://github.com/metabase/metabase/releases/tag/v0.50.0)
  - Attempting to fetch internal user raises 400 Not able to modify the internal user
  - Database creation was separated from initial setup
- Pinning Metabase and dbt versions for reproducibility while testing
- Minor fixes to Makefile to enable development on Linux