### PR TITLE
Custom Metabase image for sandbox

### DIFF
--- a/sandbox/Dockerfile-metabase
+++ b/sandbox/Dockerfile-metabase
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:11-jre
+
+ARG MB_VERSION
+
+RUN curl -O https://downloads.metabase.com/v${MB_VERSION}/metabase.jar
+
+EXPOSE 3000
+
+ENTRYPOINT ["java", "-jar", "metabase.jar"]

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -20,7 +20,11 @@ services:
     restart: always
 
   metabase:
-    image: metabase/metabase:v0.50.0
+    # image: metabase/metabase:v0.50.1
+    build:
+      dockerfile: Dockerfile-metabase
+      args:
+        - MB_VERSION=0.50.1
     environment:
       - MB_SETUP_TOKEN=${MB_SETUP_TOKEN:-}
     ports:


### PR DESCRIPTION
For testing custom Metabase setup or whenever experiencing issues with the standard image, e.g. https://github.com/docker/for-mac/issues/7006.