### PR TITLE
Update tests and sandbox for dbt 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ models:
     columns:
       - name: id
         description: Primary key.
-        tests:
+        data_tests:
           - not_null
           - unique
 
@@ -65,7 +65,7 @@ models:
 
       - name: group_id
         description: Foreign key to user group.
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('groups')
@@ -76,7 +76,7 @@ models:
     columns:
       - name: id
         description: Primary key.
-        tests:
+        data_tests:
           - not_null
           - unique
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,6 @@ isort>=5.12.0
 pylint>=3.0.2
 mypy>=1.7.1
 molot~=1.0.0
-dbt-postgres~=1.7.16
+dbt-postgres~=1.8.1
 types-requests
 types-PyYAML

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -1,11 +1,14 @@
 FROM python:3.11-slim-bullseye
 
+RUN apt-get update && \
+    apt-get install -y gcc libpq-dev
+
 WORKDIR /app
 
 COPY --from=root requirements.txt ./
 COPY --from=root requirements-test.txt ./
 
-RUN pip install -r requirements.txt -r requirements-test.txt
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-test.txt
 
 WORKDIR /app/sandbox
 

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -20,11 +20,11 @@ services:
     restart: always
 
   metabase:
-    # image: metabase/metabase:v0.50.1
+    # image: metabase/metabase:latest
     build:
       dockerfile: Dockerfile-metabase
       args:
-        - MB_VERSION=0.50.1
+        - MB_VERSION=0.50.3
     environment:
       - MB_SETUP_TOKEN=${MB_SETUP_TOKEN:-}
     ports:

--- a/sandbox/models/schema.yml
+++ b/sandbox/models/schema.yml
@@ -9,7 +9,7 @@ models:
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -44,7 +44,7 @@ models:
       - name: order_id
         constraints:
           - type: primary_key
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
@@ -54,38 +54,38 @@ models:
         constraints:
           - type: foreign_key
             expression: customers (customer_id)
-        tests:
+        data_tests:
           - not_null
 
       - name: order_date
         description: Date (UTC) that the order was placed
 
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/sandbox/models/staging/schema.yml
+++ b/sandbox/models/staging/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: stg_customers
     columns:
       - name: customer_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: first_name
@@ -13,11 +13,11 @@ models:
   - name: stg_orders
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: status
-        tests:
+        data_tests:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
       - name: order_date
@@ -26,11 +26,11 @@ models:
   - name: stg_payments
     columns:
       - name: payment_id
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: payment_method
-        tests:
+        data_tests:
           - accepted_values:
               values: ['credit_card', 'coupon', 'bank_transfer', 'gift_card']
       - name: order_id

--- a/tests/_mocks.py
+++ b/tests/_mocks.py
@@ -16,10 +16,10 @@ class MockMetabase(Metabase):
     def __init__(self, url: str):
         super().__init__(
             url=url,
-            api_key=None,
-            username=None,
+            api_key="dummy",
+            username="None",
             password=None,
-            session_id="dummy",
+            session_id=None,
             skip_verify=False,
             cert=None,
             http_timeout=1,

--- a/tests/fixtures/manifest-v12.json
+++ b/tests/fixtures/manifest-v12.json
@@ -1,13 +1,13 @@
 {
     "metadata": {
-        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-        "dbt_version": "1.7.8",
-        "generated_at": "2024-02-20T01:11:30.963279Z",
-        "invocation_id": "e0c2a315-8369-44bf-8cad-a6cbb98ce697",
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+        "dbt_version": "1.8.2",
+        "generated_at": "2024-06-14T05:23:02.213468Z",
+        "invocation_id": "5c8dbbf7-3263-4bac-a4d1-20e2dd17136b",
         "env": {},
         "project_name": "sandbox",
         "project_id": "93bc63e0b4f48fbbff568d9fc0dc3def",
-        "user_id": "1ef6fcbd-9ade-4ab0-946c-c22863d616f0",
+        "user_id": "4713f682-4b45-42e9-aa02-ae7bec4a4da1",
         "send_anonymous_usage_stats": true,
         "adapter_type": "postgres"
     },
@@ -143,14 +143,13 @@
             },
             "patch_path": "sandbox://models/schema.yml",
             "build_path": "target/run/sandbox/models/customers.sql",
-            "deferred": false,
             "unrendered_config": {
                 "materialized": "table",
                 "meta": {
                     "metabase.display_name": "clients"
                 }
             },
-            "created_at": 1708330299.0858583,
+            "created_at": 1718342580.747703,
             "relation_name": "\"dbtmetabase\".\"public\".\"customers\"",
             "raw_code": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final",
             "language": "sql",
@@ -196,1528 +195,6 @@
             "version": null,
             "latest_version": null,
             "deprecation_date": null
-        },
-        "seed.sandbox.raw_customers": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "raw_customers",
-            "resource_type": "seed",
-            "package_name": "sandbox",
-            "path": "raw_customers.csv",
-            "original_file_path": "seeds/raw_customers.csv",
-            "unique_id": "seed.sandbox.raw_customers",
-            "fqn": [
-                "sandbox",
-                "raw_customers"
-            ],
-            "alias": "raw_customers",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "357d173dda65a741ad97d6683502286cc2655bb396ab5f4dfad12b8c39bd2a63"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "seed",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "delimiter": ",",
-                "quote_columns": null
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708330299.0421724,
-            "relation_name": "\"dbtmetabase\".\"public\".\"raw_customers\"",
-            "raw_code": "",
-            "root_path": "/app/sandbox",
-            "depends_on": {
-                "macros": []
-            }
-        },
-        "seed.sandbox.raw_orders": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "raw_orders",
-            "resource_type": "seed",
-            "package_name": "sandbox",
-            "path": "raw_orders.csv",
-            "original_file_path": "seeds/raw_orders.csv",
-            "unique_id": "seed.sandbox.raw_orders",
-            "fqn": [
-                "sandbox",
-                "raw_orders"
-            ],
-            "alias": "raw_orders",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "6228dde8e17b9621f35c13e272ec67d3ff55b55499433f47d303adf2be72c17f"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "seed",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "delimiter": ",",
-                "quote_columns": null
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708330299.0437803,
-            "relation_name": "\"dbtmetabase\".\"public\".\"raw_orders\"",
-            "raw_code": "",
-            "root_path": "/app/sandbox",
-            "depends_on": {
-                "macros": []
-            }
-        },
-        "seed.sandbox.raw_payments": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "raw_payments",
-            "resource_type": "seed",
-            "package_name": "sandbox",
-            "path": "raw_payments.csv",
-            "original_file_path": "seeds/raw_payments.csv",
-            "unique_id": "seed.sandbox.raw_payments",
-            "fqn": [
-                "sandbox",
-                "raw_payments"
-            ],
-            "alias": "raw_payments",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "6de0626a8db9c1750eefd1b2e17fac4c2a4b9f778eb50532d8b377b90de395e6"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "seed",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "delimiter": ",",
-                "quote_columns": null
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708330299.045119,
-            "relation_name": "\"dbtmetabase\".\"public\".\"raw_payments\"",
-            "raw_code": "",
-            "root_path": "/app/sandbox",
-            "depends_on": {
-                "macros": []
-            }
-        },
-        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": {
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "unique_customers_customer_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "unique_customers_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.unique_customers_customer_id.c5af1ff4b1",
-            "fqn": [
-                "sandbox",
-                "unique_customers_customer_id"
-            ],
-            "alias": "unique_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708330299.1369452,
-            "relation_name": null,
-            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.sandbox.customers"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.customers",
-            "attached_node": "model.sandbox.customers"
-        },
-        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('customers')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_customers_customer_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_customers_customer_id.sql",
-            "original_file_path": "models/schema.yml",
-            "unique_id": "test.sandbox.not_null_customers_customer_id.5c9bf9911d",
-            "fqn": [
-                "sandbox",
-                "not_null_customers_customer_id"
-            ],
-            "alias": "not_null_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708330299.1383352,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.customers"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.customers",
-            "attached_node": "model.sandbox.customers"
-        },
-        "model.sandbox.stg_customers": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "stg_customers",
-            "resource_type": "model",
-            "package_name": "sandbox",
-            "path": "staging/stg_customers.sql",
-            "original_file_path": "models/staging/stg_customers.sql",
-            "unique_id": "model.sandbox.stg_customers",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "stg_customers"
-            ],
-            "alias": "stg_customers",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "80e3223cd54387e11fa16cd0f4cbe15f8ff74dcd9900b93856b9e39416178c9d"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "view",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "access": "protected"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {
-                "customer_id": {
-                    "name": "customer_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "first_name": {
-                    "name": "first_name",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "last_name": {
-                    "name": "last_name",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": "sandbox://models/staging/schema.yml",
-            "build_path": "target/run/sandbox/models/staging/stg_customers.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "materialized": "view"
-            },
-            "created_at": 1708338357.5425656,
-            "relation_name": "\"dbtmetabase\".\"public\".\"stg_customers\"",
-            "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "raw_customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "seed.sandbox.raw_customers"
-                ]
-            },
-            "compiled_path": "target/compiled/sandbox/models/staging/stg_customers.sql",
-            "compiled": true,
-            "compiled_code": "with source as (\n    select * from \"dbtmetabase\".\"public\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "access": "protected",
-            "constraints": [],
-            "version": null,
-            "latest_version": null,
-            "deprecation_date": null
-        },
-        "model.sandbox.stg_payments": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "stg_payments",
-            "resource_type": "model",
-            "package_name": "sandbox",
-            "path": "staging/stg_payments.sql",
-            "original_file_path": "models/staging/stg_payments.sql",
-            "unique_id": "model.sandbox.stg_payments",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "stg_payments"
-            ],
-            "alias": "stg_payments",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "e9a45326cc72cf5bdc59163207bac2f3ed3697c1758d916b17327c7720110fcc"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "view",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "access": "protected"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {
-                "payment_id": {
-                    "name": "payment_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "payment_method": {
-                    "name": "payment_method",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "order_id": {
-                    "name": "order_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "amount": {
-                    "name": "amount",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": "sandbox://models/staging/schema.yml",
-            "build_path": "target/run/sandbox/models/staging/stg_payments.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "materialized": "view"
-            },
-            "created_at": 1708338357.5437949,
-            "relation_name": "\"dbtmetabase\".\"public\".\"stg_payments\"",
-            "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "raw_payments",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "seed.sandbox.raw_payments"
-                ]
-            },
-            "compiled_path": "target/compiled/sandbox/models/staging/stg_payments.sql",
-            "compiled": true,
-            "compiled_code": "with source as (\n    select * from \"dbtmetabase\".\"public\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "access": "protected",
-            "constraints": [],
-            "version": null,
-            "latest_version": null,
-            "deprecation_date": null
-        },
-        "model.sandbox.stg_orders": {
-            "database": "dbtmetabase",
-            "schema": "public",
-            "name": "stg_orders",
-            "resource_type": "model",
-            "package_name": "sandbox",
-            "path": "staging/stg_orders.sql",
-            "original_file_path": "models/staging/stg_orders.sql",
-            "unique_id": "model.sandbox.stg_orders",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "stg_orders"
-            ],
-            "alias": "stg_orders",
-            "checksum": {
-                "name": "sha256",
-                "checksum": "f4f881cb09d2c4162200fc331d7401df6d1abd4fed492554a7db70dede347108"
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": null,
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "view",
-                "incremental_strategy": null,
-                "persist_docs": {},
-                "post-hook": [],
-                "pre-hook": [],
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": null,
-                "unique_key": null,
-                "on_schema_change": "ignore",
-                "on_configuration_change": "apply",
-                "grants": {},
-                "packages": [],
-                "docs": {
-                    "show": true,
-                    "node_color": null
-                },
-                "contract": {
-                    "enforced": false,
-                    "alias_types": true
-                },
-                "access": "protected"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {
-                "order_id": {
-                    "name": "order_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "status": {
-                    "name": "status",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "order_date": {
-                    "name": "order_date",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                },
-                "customer_id": {
-                    "name": "customer_id",
-                    "description": "",
-                    "meta": {},
-                    "data_type": null,
-                    "constraints": [],
-                    "quote": null,
-                    "tags": []
-                }
-            },
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": "sandbox://models/staging/schema.yml",
-            "build_path": "target/run/sandbox/models/staging/stg_orders.sql",
-            "deferred": false,
-            "unrendered_config": {
-                "materialized": "view"
-            },
-            "created_at": 1708338357.5444813,
-            "relation_name": "\"dbtmetabase\".\"public\".\"stg_orders\"",
-            "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "raw_orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "seed.sandbox.raw_orders"
-                ]
-            },
-            "compiled_path": "target/compiled/sandbox/models/staging/stg_orders.sql",
-            "compiled": true,
-            "compiled_code": "with source as (\n    select * from \"dbtmetabase\".\"public\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
-            "extra_ctes_injected": true,
-            "extra_ctes": [],
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "access": "protected",
-            "constraints": [],
-            "version": null,
-            "latest_version": null,
-            "deprecation_date": null
-        },
-        "test.sandbox.unique_stg_customers_customer_id.c7614daada": {
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "unique_stg_customers_customer_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "unique_stg_customers_customer_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.unique_stg_customers_customer_id.c7614daada",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "unique_stg_customers_customer_id"
-            ],
-            "alias": "unique_stg_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708338357.5923638,
-            "relation_name": null,
-            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_customers"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.stg_customers",
-            "attached_node": "model.sandbox.stg_customers"
-        },
-        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "customer_id",
-                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_stg_customers_customer_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_stg_customers_customer_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "not_null_stg_customers_customer_id"
-            ],
-            "alias": "not_null_stg_customers_customer_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708338357.5937386,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_customers"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "customer_id",
-            "file_key_name": "models.stg_customers",
-            "attached_node": "model.sandbox.stg_customers"
-        },
-        "test.sandbox.unique_stg_payments_payment_id.3744510712": {
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "payment_id",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "unique_stg_payments_payment_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "unique_stg_payments_payment_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.unique_stg_payments_payment_id.3744510712",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "unique_stg_payments_payment_id"
-            ],
-            "alias": "unique_stg_payments_payment_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708338357.595022,
-            "relation_name": null,
-            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_payments",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_payments"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "payment_id",
-            "file_key_name": "models.stg_payments",
-            "attached_node": "model.sandbox.stg_payments"
-        },
-        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "payment_id",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_stg_payments_payment_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_stg_payments_payment_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.not_null_stg_payments_payment_id.c19cc50075",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "not_null_stg_payments_payment_id"
-            ],
-            "alias": "not_null_stg_payments_payment_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708338357.5963225,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_payments",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_payments"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "payment_id",
-            "file_key_name": "models.stg_payments",
-            "attached_node": "model.sandbox.stg_payments"
-        },
-        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
-            "test_metadata": {
-                "name": "accepted_values",
-                "kwargs": {
-                    "values": [
-                        "credit_card",
-                        "coupon",
-                        "bank_transfer",
-                        "gift_card"
-                    ],
-                    "column_name": "payment_method",
-                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
-            ],
-            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {
-                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
-            },
-            "created_at": 1708338357.5973942,
-            "relation_name": null,
-            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_payments",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_accepted_values",
-                    "macro.dbt.get_where_subquery"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_payments"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "payment_method",
-            "file_key_name": "models.stg_payments",
-            "attached_node": "model.sandbox.stg_payments"
-        },
-        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": {
-            "test_metadata": {
-                "name": "unique",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "unique_stg_orders_order_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "unique_stg_orders_order_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.unique_stg_orders_order_id.e3b841c71a",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "unique_stg_orders_order_id"
-            ],
-            "alias": "unique_stg_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708338357.6061413,
-            "relation_name": null,
-            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_unique"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "order_id",
-            "file_key_name": "models.stg_orders",
-            "attached_node": "model.sandbox.stg_orders"
-        },
-        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": {
-            "test_metadata": {
-                "name": "not_null",
-                "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "not_null_stg_orders_order_id",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "not_null_stg_orders_order_id.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "not_null_stg_orders_order_id"
-            ],
-            "alias": "not_null_stg_orders_order_id",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": null,
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {},
-            "created_at": 1708338357.6072319,
-            "relation_name": null,
-            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_not_null"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "order_id",
-            "file_key_name": "models.stg_orders",
-            "attached_node": "model.sandbox.stg_orders"
-        },
-        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": {
-            "test_metadata": {
-                "name": "accepted_values",
-                "kwargs": {
-                    "values": [
-                        "placed",
-                        "shipped",
-                        "completed",
-                        "return_pending",
-                        "returned"
-                    ],
-                    "column_name": "status",
-                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
-                },
-                "namespace": null
-            },
-            "database": "dbtmetabase",
-            "schema": "public_dbt_test__audit",
-            "name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
-            "resource_type": "test",
-            "package_name": "sandbox",
-            "path": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
-            "original_file_path": "models/staging/schema.yml",
-            "unique_id": "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
-            "fqn": [
-                "sandbox",
-                "staging",
-                "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"
-            ],
-            "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
-            "checksum": {
-                "name": "none",
-                "checksum": ""
-            },
-            "config": {
-                "enabled": true,
-                "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
-                "schema": "dbt_test__audit",
-                "database": null,
-                "tags": [],
-                "meta": {},
-                "group": null,
-                "materialized": "test",
-                "severity": "ERROR",
-                "store_failures": null,
-                "store_failures_as": null,
-                "where": null,
-                "limit": null,
-                "fail_calc": "count(*)",
-                "warn_if": "!= 0",
-                "error_if": "!= 0"
-            },
-            "tags": [],
-            "description": "",
-            "columns": {},
-            "meta": {},
-            "group": null,
-            "docs": {
-                "show": true,
-                "node_color": null
-            },
-            "patch_path": null,
-            "build_path": null,
-            "deferred": false,
-            "unrendered_config": {
-                "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
-            },
-            "created_at": 1708338357.6084142,
-            "relation_name": null,
-            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
-            "language": "sql",
-            "refs": [
-                {
-                    "name": "stg_orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "depends_on": {
-                "macros": [
-                    "macro.dbt.test_accepted_values",
-                    "macro.dbt.get_where_subquery"
-                ],
-                "nodes": [
-                    "model.sandbox.stg_orders"
-                ]
-            },
-            "compiled_path": null,
-            "contract": {
-                "enforced": false,
-                "alias_types": true,
-                "checksum": null
-            },
-            "column_name": "status",
-            "file_key_name": "models.stg_orders",
-            "attached_node": "model.sandbox.stg_orders"
         },
         "model.sandbox.orders": {
             "database": "dbtmetabase",
@@ -1883,7 +360,6 @@
             },
             "patch_path": "sandbox://models/schema.yml",
             "build_path": "target/run/sandbox/models/orders.sql",
-            "deferred": false,
             "unrendered_config": {
                 "materialized": "table",
                 "meta": {
@@ -1891,7 +367,7 @@
                     "metabase.caveats": "Some facts are derived from payments"
                 }
             },
-            "created_at": 1708391489.32839,
+            "created_at": 1718342580.7505133,
             "relation_name": "\"dbtmetabase\".\"public\".\"orders\"",
             "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
             "language": "sql",
@@ -1932,15 +408,790 @@
             "latest_version": null,
             "deprecation_date": null
         },
-        "test.sandbox.unique_orders_order_id.fed79b3a6e": {
+        "model.sandbox.stg_customers": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "stg_customers",
+            "resource_type": "model",
+            "package_name": "sandbox",
+            "path": "staging/stg_customers.sql",
+            "original_file_path": "models/staging/stg_customers.sql",
+            "unique_id": "model.sandbox.stg_customers",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "stg_customers"
+            ],
+            "alias": "stg_customers",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "80e3223cd54387e11fa16cd0f4cbe15f8ff74dcd9900b93856b9e39416178c9d"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "view",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "first_name": {
+                    "name": "first_name",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "last_name": {
+                    "name": "last_name",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "sandbox://models/staging/schema.yml",
+            "build_path": "target/run/sandbox/models/staging/stg_customers.sql",
+            "unrendered_config": {
+                "materialized": "view"
+            },
+            "created_at": 1718342580.8049898,
+            "relation_name": "\"dbtmetabase\".\"public\".\"stg_customers\"",
+            "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "raw_customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "seed.sandbox.raw_customers"
+                ]
+            },
+            "compiled_path": "target/compiled/sandbox/models/staging/stg_customers.sql",
+            "compiled": true,
+            "compiled_code": "with source as (\n    select * from \"dbtmetabase\".\"public\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "model.sandbox.stg_payments": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "stg_payments",
+            "resource_type": "model",
+            "package_name": "sandbox",
+            "path": "staging/stg_payments.sql",
+            "original_file_path": "models/staging/stg_payments.sql",
+            "unique_id": "model.sandbox.stg_payments",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "stg_payments"
+            ],
+            "alias": "stg_payments",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "e9a45326cc72cf5bdc59163207bac2f3ed3697c1758d916b17327c7720110fcc"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "view",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {
+                "payment_id": {
+                    "name": "payment_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "payment_method": {
+                    "name": "payment_method",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "order_id": {
+                    "name": "order_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "amount": {
+                    "name": "amount",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "sandbox://models/staging/schema.yml",
+            "build_path": "target/run/sandbox/models/staging/stg_payments.sql",
+            "unrendered_config": {
+                "materialized": "view"
+            },
+            "created_at": 1718342580.8059077,
+            "relation_name": "\"dbtmetabase\".\"public\".\"stg_payments\"",
+            "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "raw_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "seed.sandbox.raw_payments"
+                ]
+            },
+            "compiled_path": "target/compiled/sandbox/models/staging/stg_payments.sql",
+            "compiled": true,
+            "compiled_code": "with source as (\n    select * from \"dbtmetabase\".\"public\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "model.sandbox.stg_orders": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "stg_orders",
+            "resource_type": "model",
+            "package_name": "sandbox",
+            "path": "staging/stg_orders.sql",
+            "original_file_path": "models/staging/stg_orders.sql",
+            "unique_id": "model.sandbox.stg_orders",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "stg_orders"
+            ],
+            "alias": "stg_orders",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "f4f881cb09d2c4162200fc331d7401df6d1abd4fed492554a7db70dede347108"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "view",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {
+                "order_id": {
+                    "name": "order_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "status": {
+                    "name": "status",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "order_date": {
+                    "name": "order_date",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": null,
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "sandbox://models/staging/schema.yml",
+            "build_path": "target/run/sandbox/models/staging/stg_orders.sql",
+            "unrendered_config": {
+                "materialized": "view"
+            },
+            "created_at": 1718342580.80533,
+            "relation_name": "\"dbtmetabase\".\"public\".\"stg_orders\"",
+            "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "raw_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "seed.sandbox.raw_orders"
+                ]
+            },
+            "compiled_path": "target/compiled/sandbox/models/staging/stg_orders.sql",
+            "compiled": true,
+            "compiled_code": "with source as (\n    select * from \"dbtmetabase\".\"public\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "seed.sandbox.raw_customers": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "raw_customers",
+            "resource_type": "seed",
+            "package_name": "sandbox",
+            "path": "raw_customers.csv",
+            "original_file_path": "seeds/raw_customers.csv",
+            "unique_id": "seed.sandbox.raw_customers",
+            "fqn": [
+                "sandbox",
+                "raw_customers"
+            ],
+            "alias": "raw_customers",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "357d173dda65a741ad97d6683502286cc2655bb396ab5f4dfad12b8c39bd2a63"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.708184,
+            "relation_name": "\"dbtmetabase\".\"public\".\"raw_customers\"",
+            "raw_code": "",
+            "root_path": "/app/sandbox",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "seed.sandbox.raw_orders": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "raw_orders",
+            "resource_type": "seed",
+            "package_name": "sandbox",
+            "path": "raw_orders.csv",
+            "original_file_path": "seeds/raw_orders.csv",
+            "unique_id": "seed.sandbox.raw_orders",
+            "fqn": [
+                "sandbox",
+                "raw_orders"
+            ],
+            "alias": "raw_orders",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "6228dde8e17b9621f35c13e272ec67d3ff55b55499433f47d303adf2be72c17f"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.7092662,
+            "relation_name": "\"dbtmetabase\".\"public\".\"raw_orders\"",
+            "raw_code": "",
+            "root_path": "/app/sandbox",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "seed.sandbox.raw_payments": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "raw_payments",
+            "resource_type": "seed",
+            "package_name": "sandbox",
+            "path": "raw_payments.csv",
+            "original_file_path": "seeds/raw_payments.csv",
+            "unique_id": "seed.sandbox.raw_payments",
+            "fqn": [
+                "sandbox",
+                "raw_payments"
+            ],
+            "alias": "raw_payments",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "6de0626a8db9c1750eefd1b2e17fac4c2a4b9f778eb50532d8b377b90de395e6"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.710562,
+            "relation_name": "\"dbtmetabase\".\"public\".\"raw_payments\"",
+            "raw_code": "",
+            "root_path": "/app/sandbox",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "unique_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "unique_customers_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.unique_customers_customer_id.c5af1ff4b1",
+            "fqn": [
+                "sandbox",
+                "unique_customers_customer_id"
+            ],
+            "alias": "unique_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.7866974,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.sandbox.customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.customers",
+            "attached_node": "model.sandbox.customers",
             "test_metadata": {
                 "name": "unique",
                 "kwargs": {
-                    "column_name": "order_id",
-                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('customers')) }}"
                 },
                 "namespace": null
+            }
+        },
+        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_customers_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.sandbox.not_null_customers_customer_id.5c9bf9911d",
+            "fqn": [
+                "sandbox",
+                "not_null_customers_customer_id"
+            ],
+            "alias": "not_null_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
             },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.7876441,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.customers",
+            "attached_node": "model.sandbox.customers",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.unique_orders_order_id.fed79b3a6e": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "unique_orders_order_id",
@@ -1987,9 +1238,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.3618965,
+            "created_at": 1718342580.788374,
             "relation_name": null,
             "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2018,17 +1268,17 @@
             },
             "column_name": "order_id",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_order_id.cf6c17daed": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
-                "name": "not_null",
+                "name": "unique",
                 "kwargs": {
                     "column_name": "order_id",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.not_null_orders_order_id.cf6c17daed": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "not_null_orders_order_id",
@@ -2075,9 +1325,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.362866,
+            "created_at": 1718342580.789079,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2106,17 +1355,17 @@
             },
             "column_name": "order_id",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_customer_id.c5f02694af": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
                 "name": "not_null",
                 "kwargs": {
-                    "column_name": "customer_id",
+                    "column_name": "order_id",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.not_null_orders_customer_id.c5f02694af": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "not_null_orders_customer_id",
@@ -2163,9 +1412,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.3637223,
+            "created_at": 1718342580.7897742,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2194,24 +1442,17 @@
             },
             "column_name": "customer_id",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
-                "name": "accepted_values",
+                "name": "not_null",
                 "kwargs": {
-                    "values": [
-                        "placed",
-                        "shipped",
-                        "completed",
-                        "return_pending",
-                        "returned"
-                    ],
-                    "column_name": "status",
+                    "column_name": "customer_id",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
@@ -2258,11 +1499,10 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {
                 "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
             },
-            "created_at": 1708391489.3645678,
+            "created_at": 1718342580.7904375,
             "relation_name": null,
             "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
             "language": "sql",
@@ -2292,17 +1532,24 @@
             },
             "column_name": "status",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_amount.106140f9fd": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
-                "name": "not_null",
+                "name": "accepted_values",
                 "kwargs": {
-                    "column_name": "amount",
+                    "values": [
+                        "placed",
+                        "shipped",
+                        "completed",
+                        "return_pending",
+                        "returned"
+                    ],
+                    "column_name": "status",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.not_null_orders_amount.106140f9fd": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "not_null_orders_amount",
@@ -2349,9 +1596,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.3704727,
+            "created_at": 1718342580.800781,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2380,17 +1626,17 @@
             },
             "column_name": "amount",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
                 "name": "not_null",
                 "kwargs": {
-                    "column_name": "credit_card_amount",
+                    "column_name": "amount",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "not_null_orders_credit_card_amount",
@@ -2437,9 +1683,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.3713634,
+            "created_at": 1718342580.8014944,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2468,17 +1713,17 @@
             },
             "column_name": "credit_card_amount",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_coupon_amount.ab90c90625": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
                 "name": "not_null",
                 "kwargs": {
-                    "column_name": "coupon_amount",
+                    "column_name": "credit_card_amount",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.not_null_orders_coupon_amount.ab90c90625": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "not_null_orders_coupon_amount",
@@ -2525,9 +1770,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.3721504,
+            "created_at": 1718342580.8021913,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2556,17 +1800,17 @@
             },
             "column_name": "coupon_amount",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
                 "name": "not_null",
                 "kwargs": {
-                    "column_name": "bank_transfer_amount",
+                    "column_name": "coupon_amount",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "not_null_orders_bank_transfer_amount",
@@ -2613,9 +1857,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.3729131,
+            "created_at": 1718342580.8028505,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2644,17 +1887,17 @@
             },
             "column_name": "bank_transfer_amount",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
-        },
-        "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": {
+            "attached_node": "model.sandbox.orders",
             "test_metadata": {
                 "name": "not_null",
                 "kwargs": {
-                    "column_name": "gift_card_amount",
+                    "column_name": "bank_transfer_amount",
                     "model": "{{ get_where_subquery(ref('orders')) }}"
                 },
                 "namespace": null
-            },
+            }
+        },
+        "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": {
             "database": "dbtmetabase",
             "schema": "public_dbt_test__audit",
             "name": "not_null_orders_gift_card_amount",
@@ -2701,9 +1944,8 @@
             },
             "patch_path": null,
             "build_path": null,
-            "deferred": false,
             "unrendered_config": {},
-            "created_at": 1708391489.3737113,
+            "created_at": 1718342580.803492,
             "relation_name": null,
             "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
             "language": "sql",
@@ -2732,7 +1974,738 @@
             },
             "column_name": "gift_card_amount",
             "file_key_name": "models.orders",
-            "attached_node": "model.sandbox.orders"
+            "attached_node": "model.sandbox.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "gift_card_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.unique_stg_customers_customer_id.c7614daada": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "unique_stg_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "unique_stg_customers_customer_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.unique_stg_customers_customer_id.c7614daada",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "unique_stg_customers_customer_id"
+            ],
+            "alias": "unique_stg_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.806266,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.stg_customers",
+            "attached_node": "model.sandbox.stg_customers",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_stg_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_stg_customers_customer_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "not_null_stg_customers_customer_id"
+            ],
+            "alias": "not_null_stg_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.8069677,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.stg_customers",
+            "attached_node": "model.sandbox.stg_customers",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "unique_stg_orders_order_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "unique_stg_orders_order_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.unique_stg_orders_order_id.e3b841c71a",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "unique_stg_orders_order_id"
+            ],
+            "alias": "unique_stg_orders_order_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.807811,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "order_id",
+            "file_key_name": "models.stg_orders",
+            "attached_node": "model.sandbox.stg_orders",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_stg_orders_order_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_stg_orders_order_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "not_null_stg_orders_order_id"
+            ],
+            "alias": "not_null_stg_orders_order_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.837896,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "order_id",
+            "file_key_name": "models.stg_orders",
+            "attached_node": "model.sandbox.stg_orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"
+            ],
+            "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {
+                "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
+            },
+            "created_at": 1718342580.8387535,
+            "relation_name": null,
+            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_accepted_values",
+                    "macro.dbt.get_where_subquery"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "status",
+            "file_key_name": "models.stg_orders",
+            "attached_node": "model.sandbox.stg_orders",
+            "test_metadata": {
+                "name": "accepted_values",
+                "kwargs": {
+                    "values": [
+                        "placed",
+                        "shipped",
+                        "completed",
+                        "return_pending",
+                        "returned"
+                    ],
+                    "column_name": "status",
+                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.unique_stg_payments_payment_id.3744510712": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "unique_stg_payments_payment_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "unique_stg_payments_payment_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.unique_stg_payments_payment_id.3744510712",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "unique_stg_payments_payment_id"
+            ],
+            "alias": "unique_stg_payments_payment_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.8411777,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_id",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.sandbox.stg_payments",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "payment_id",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "not_null_stg_payments_payment_id",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "not_null_stg_payments_payment_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.not_null_stg_payments_payment_id.c19cc50075",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "not_null_stg_payments_payment_id"
+            ],
+            "alias": "not_null_stg_payments_payment_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1718342580.8418767,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_id",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.sandbox.stg_payments",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "payment_id",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
+            "database": "dbtmetabase",
+            "schema": "public_dbt_test__audit",
+            "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+            "resource_type": "test",
+            "package_name": "sandbox",
+            "path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+            "fqn": [
+                "sandbox",
+                "staging",
+                "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
+            ],
+            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {
+                "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+            },
+            "created_at": 1718342580.8425684,
+            "relation_name": null,
+            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_accepted_values",
+                    "macro.dbt.get_where_subquery"
+                ],
+                "nodes": [
+                    "model.sandbox.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_method",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.sandbox.stg_payments",
+            "test_metadata": {
+                "name": "accepted_values",
+                "kwargs": {
+                    "values": [
+                        "credit_card",
+                        "coupon",
+                        "bank_transfer",
+                        "gift_card"
+                    ],
+                    "column_name": "payment_method",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            }
         }
     },
     "sources": {},
@@ -2756,7 +2729,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.500109,
+            "created_at": 1718342580.281623,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__snapshot_string_as_time": {
@@ -2778,7 +2751,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.50035,
+            "created_at": 1718342580.2818005,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__snapshot_get_time": {
@@ -2802,7 +2775,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5004683,
+            "created_at": 1718342580.281886,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__current_timestamp_backcompat": {
@@ -2826,7 +2799,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5006177,
+            "created_at": 1718342580.2819638,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__current_timestamp_in_utc_backcompat": {
@@ -2850,7 +2823,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.500729,
+            "created_at": 1718342580.2820435,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__create_table_as": {
@@ -2877,7 +2850,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5101242,
+            "created_at": 1718342580.2895832,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_create_index_sql": {
@@ -2887,7 +2860,7 @@
             "path": "macros/adapters.sql",
             "original_file_path": "macros/adapters.sql",
             "unique_id": "macro.dbt_postgres.postgres__get_create_index_sql",
-            "macro_sql": "{% macro postgres__get_create_index_sql(relation, index_dict) -%}\n  {%- set index_config = adapter.parse_index(index_dict) -%}\n  {%- set comma_separated_columns = \", \".join(index_config.columns) -%}\n  {%- set index_name = index_config.render(relation) -%}\n\n  create {% if index_config.unique -%}\n    unique\n  {%- endif %} index if not exists\n  \"{{ index_name }}\"\n  on {{ relation }} {% if index_config.type -%}\n    using {{ index_config.type }}\n  {%- endif %}\n  ({{ comma_separated_columns }});\n{%- endmacro %}",
+            "macro_sql": "{% macro postgres__get_create_index_sql(relation, index_dict) -%}\n  {%- set index_config = adapter.parse_index(index_dict) -%}\n  {%- set comma_separated_columns = \", \".join(index_config.columns) -%}\n  {%- set index_name = index_config.render(relation) -%}\n\n  create {% if index_config.unique -%}\n    unique\n  {%- endif %} index if not exists\n  \"{{ index_name }}\"\n  on {{ relation }} {% if index_config.type -%}\n    using {{ index_config.type }}\n  {%- endif %}\n  ({{ comma_separated_columns }})\n{%- endmacro %}",
             "depends_on": {
                 "macros": []
             },
@@ -2899,7 +2872,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5106356,
+            "created_at": 1718342580.2900841,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__create_schema": {
@@ -2923,7 +2896,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.510947,
+            "created_at": 1718342580.2903237,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_schema": {
@@ -2947,7 +2920,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5112536,
+            "created_at": 1718342580.290559,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_columns_in_relation": {
@@ -2972,7 +2945,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5117238,
+            "created_at": 1718342580.2908957,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__list_relations_without_caching": {
@@ -2996,7 +2969,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.512267,
+            "created_at": 1718342580.2911997,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__information_schema_name": {
@@ -3018,7 +2991,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5124376,
+            "created_at": 1718342580.2913172,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__list_schemas": {
@@ -3042,7 +3015,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.512787,
+            "created_at": 1718342580.2916827,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__check_schema_exists": {
@@ -3066,7 +3039,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.513163,
+            "created_at": 1718342580.2919967,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_relation_with_suffix": {
@@ -3088,7 +3061,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5140045,
+            "created_at": 1718342580.2926402,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_intermediate_relation": {
@@ -3112,7 +3085,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.514195,
+            "created_at": 1718342580.2927878,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_temp_relation": {
@@ -3136,7 +3109,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.514516,
+            "created_at": 1718342580.2930126,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__make_backup_relation": {
@@ -3160,7 +3133,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5147827,
+            "created_at": 1718342580.293217,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres_escape_comment": {
@@ -3182,7 +3155,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.515186,
+            "created_at": 1718342580.293546,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__alter_relation_comment": {
@@ -3206,7 +3179,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5154004,
+            "created_at": 1718342580.2937047,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__alter_column_comment": {
@@ -3230,7 +3203,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5159972,
+            "created_at": 1718342580.294156,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_show_grant_sql": {
@@ -3252,7 +3225,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5162005,
+            "created_at": 1718342580.2943137,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__copy_grants": {
@@ -3274,7 +3247,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.516311,
+            "created_at": 1718342580.2943985,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_show_indexes_sql": {
@@ -3296,7 +3269,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5165095,
+            "created_at": 1718342580.294567,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_drop_index_sql": {
@@ -3318,7 +3291,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5166447,
+            "created_at": 1718342580.2946677,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_catalog_relations": {
@@ -3342,7 +3315,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5183465,
+            "created_at": 1718342580.295994,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_catalog": {
@@ -3366,7 +3339,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5188854,
+            "created_at": 1718342580.2962687,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_relations": {
@@ -3390,7 +3363,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.519621,
+            "created_at": 1718342580.296919,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres_get_relations": {
@@ -3414,7 +3387,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.519743,
+            "created_at": 1718342580.2970212,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_incremental_default_sql": {
@@ -3439,7 +3412,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5201066,
+            "created_at": 1718342580.2973115,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__snapshot_merge_sql": {
@@ -3461,7 +3434,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5208235,
+            "created_at": 1718342580.2978735,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_replace_view_sql": {
@@ -3485,7 +3458,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5213654,
+            "created_at": 1718342580.2982893,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_view": {
@@ -3507,7 +3480,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5215158,
+            "created_at": 1718342580.2983916,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_rename_view_sql": {
@@ -3529,7 +3502,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5216765,
+            "created_at": 1718342580.2985115,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_replace_table_sql": {
@@ -3555,7 +3528,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5223463,
+            "created_at": 1718342580.2992072,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_table": {
@@ -3577,7 +3550,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5224812,
+            "created_at": 1718342580.2993338,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_rename_table_sql": {
@@ -3599,7 +3572,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5226514,
+            "created_at": 1718342580.299453,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__refresh_materialized_view": {
@@ -3621,7 +3594,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5227792,
+            "created_at": 1718342580.2995586,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__describe_materialized_view": {
@@ -3646,7 +3619,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.523064,
+            "created_at": 1718342580.2997808,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__drop_materialized_view": {
@@ -3668,7 +3641,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.52329,
+            "created_at": 1718342580.2998881,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_rename_materialized_view_sql": {
@@ -3690,7 +3663,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5234535,
+            "created_at": 1718342580.3000157,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_alter_materialized_view_as_sql": {
@@ -3715,7 +3688,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.524322,
+            "created_at": 1718342580.3006923,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__update_indexes_on_materialized_view": {
@@ -3725,7 +3698,7 @@
             "path": "macros/relations/materialized_view/alter.sql",
             "original_file_path": "macros/relations/materialized_view/alter.sql",
             "unique_id": "macro.dbt_postgres.postgres__update_indexes_on_materialized_view",
-            "macro_sql": "\n\n\n{%- macro postgres__update_indexes_on_materialized_view(relation, index_changes) -%}\n    {{- log(\"Applying UPDATE INDEXES to: \" ~ relation) -}}\n\n    {%- for _index_change in index_changes -%}\n        {%- set _index = _index_change.context -%}\n\n        {%- if _index_change.action == \"drop\" -%}\n\n            {{ postgres__get_drop_index_sql(relation, _index.name) }};\n\n        {%- elif _index_change.action == \"create\" -%}\n\n            {{ postgres__get_create_index_sql(relation, _index.as_node_config) }}\n\n        {%- endif -%}\n\n    {%- endfor -%}\n\n{%- endmacro -%}\n\n\n",
+            "macro_sql": "\n\n\n{%- macro postgres__update_indexes_on_materialized_view(relation, index_changes) -%}\n    {{- log(\"Applying UPDATE INDEXES to: \" ~ relation) -}}\n\n    {%- for _index_change in index_changes -%}\n        {%- set _index = _index_change.context -%}\n\n        {%- if _index_change.action == \"drop\" -%}\n\n            {{ postgres__get_drop_index_sql(relation, _index.name) }}\n\n        {%- elif _index_change.action == \"create\" -%}\n\n            {{ postgres__get_create_index_sql(relation, _index.as_node_config) }}\n\n        {%- endif -%}\n\t{{ ';' if not loop.last else \"\" }}\n\n    {%- endfor -%}\n\n{%- endmacro -%}\n\n\n",
             "depends_on": {
                 "macros": [
                     "macro.dbt_postgres.postgres__get_drop_index_sql",
@@ -3740,7 +3713,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5248008,
+            "created_at": 1718342580.301095,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_materialized_view_configuration_changes": {
@@ -3750,7 +3723,7 @@
             "path": "macros/relations/materialized_view/alter.sql",
             "original_file_path": "macros/relations/materialized_view/alter.sql",
             "unique_id": "macro.dbt_postgres.postgres__get_materialized_view_configuration_changes",
-            "macro_sql": "{% macro postgres__get_materialized_view_configuration_changes(existing_relation, new_config) %}\n    {% set _existing_materialized_view = postgres__describe_materialized_view(existing_relation) %}\n    {% set _configuration_changes = existing_relation.get_materialized_view_config_change_collection(_existing_materialized_view, new_config) %}\n    {% do return(_configuration_changes) %}\n{% endmacro %}",
+            "macro_sql": "{% macro postgres__get_materialized_view_configuration_changes(existing_relation, new_config) %}\n    {% set _existing_materialized_view = postgres__describe_materialized_view(existing_relation) %}\n    {% set _configuration_changes = existing_relation.get_materialized_view_config_change_collection(_existing_materialized_view, new_config.model) %}\n    {% do return(_configuration_changes) %}\n{% endmacro %}",
             "depends_on": {
                 "macros": [
                     "macro.dbt_postgres.postgres__describe_materialized_view"
@@ -3764,7 +3737,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.52508,
+            "created_at": 1718342580.3013,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__get_create_materialized_view_as_sql": {
@@ -3774,7 +3747,7 @@
             "path": "macros/relations/materialized_view/create.sql",
             "original_file_path": "macros/relations/materialized_view/create.sql",
             "unique_id": "macro.dbt_postgres.postgres__get_create_materialized_view_as_sql",
-            "macro_sql": "{% macro postgres__get_create_materialized_view_as_sql(relation, sql) %}\n    create materialized view if not exists {{ relation }} as {{ sql }};\n\n    {% for _index_dict in config.get('indexes', []) -%}\n        {{- get_create_index_sql(relation, _index_dict) -}}\n    {%- endfor -%}\n\n{% endmacro %}",
+            "macro_sql": "{% macro postgres__get_create_materialized_view_as_sql(relation, sql) %}\n    create materialized view if not exists {{ relation }} as {{ sql }};\n\n    {% for _index_dict in config.get('indexes', []) -%}\n        {{- get_create_index_sql(relation, _index_dict) -}}{{ ';' if not loop.last else \"\" }}\n    {%- endfor -%}\n\n{% endmacro %}",
             "depends_on": {
                 "macros": [
                     "macro.dbt.get_create_index_sql"
@@ -3788,7 +3761,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5254297,
+            "created_at": 1718342580.3016276,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__listagg": {
@@ -3810,7 +3783,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5260458,
+            "created_at": 1718342580.3020928,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__dateadd": {
@@ -3832,7 +3805,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5262516,
+            "created_at": 1718342580.3022559,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__any_value": {
@@ -3854,7 +3827,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5263839,
+            "created_at": 1718342580.302353,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__split_part": {
@@ -3879,7 +3852,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5267837,
+            "created_at": 1718342580.3026361,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__last_day": {
@@ -3905,7 +3878,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.527255,
+            "created_at": 1718342580.3029845,
             "supported_languages": null
         },
         "macro.dbt_postgres.postgres__datediff": {
@@ -3929,7 +3902,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5305197,
+            "created_at": 1718342580.3052852,
             "supported_languages": null
         },
         "macro.dbt.generate_database_name": {
@@ -3953,7 +3926,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5309165,
+            "created_at": 1718342580.3055835,
             "supported_languages": null
         },
         "macro.dbt.default__generate_database_name": {
@@ -3975,7 +3948,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5311565,
+            "created_at": 1718342580.3057575,
             "supported_languages": null
         },
         "macro.dbt.generate_schema_name": {
@@ -3999,7 +3972,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.531699,
+            "created_at": 1718342580.3061469,
             "supported_languages": null
         },
         "macro.dbt.default__generate_schema_name": {
@@ -4021,7 +3994,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5319543,
+            "created_at": 1718342580.3063257,
             "supported_languages": null
         },
         "macro.dbt.generate_schema_name_for_env": {
@@ -4043,7 +4016,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5322382,
+            "created_at": 1718342580.3066485,
             "supported_languages": null
         },
         "macro.dbt.generate_alias_name": {
@@ -4067,7 +4040,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5326614,
+            "created_at": 1718342580.3071277,
             "supported_languages": null
         },
         "macro.dbt.default__generate_alias_name": {
@@ -4089,7 +4062,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5330265,
+            "created_at": 1718342580.3074532,
             "supported_languages": null
         },
         "macro.dbt.resolve_model_name": {
@@ -4113,7 +4086,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5347013,
+            "created_at": 1718342580.308697,
             "supported_languages": null
         },
         "macro.dbt.default__resolve_model_name": {
@@ -4135,7 +4108,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5348513,
+            "created_at": 1718342580.3089085,
             "supported_languages": null
         },
         "macro.dbt.build_ref_function": {
@@ -4159,7 +4132,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.535658,
+            "created_at": 1718342580.3094857,
             "supported_languages": null
         },
         "macro.dbt.build_source_function": {
@@ -4183,7 +4156,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.536067,
+            "created_at": 1718342580.309789,
             "supported_languages": null
         },
         "macro.dbt.build_config_dict": {
@@ -4205,7 +4178,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5366523,
+            "created_at": 1718342580.3102064,
             "supported_languages": null
         },
         "macro.dbt.py_script_postfix": {
@@ -4234,7 +4207,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5373712,
+            "created_at": 1718342580.3105428,
             "supported_languages": null
         },
         "macro.dbt.py_script_comment": {
@@ -4256,7 +4229,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.537449,
+            "created_at": 1718342580.3105974,
             "supported_languages": null
         },
         "macro.dbt.run_hooks": {
@@ -4280,7 +4253,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5387776,
+            "created_at": 1718342580.3113625,
             "supported_languages": null
         },
         "macro.dbt.make_hook_config": {
@@ -4302,7 +4275,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5390067,
+            "created_at": 1718342580.3114946,
             "supported_languages": null
         },
         "macro.dbt.before_begin": {
@@ -4326,7 +4299,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5391488,
+            "created_at": 1718342580.3116074,
             "supported_languages": null
         },
         "macro.dbt.in_transaction": {
@@ -4350,7 +4323,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.539292,
+            "created_at": 1718342580.3117213,
             "supported_languages": null
         },
         "macro.dbt.after_commit": {
@@ -4374,7 +4347,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5395236,
+            "created_at": 1718342580.3118157,
             "supported_languages": null
         },
         "macro.dbt.set_sql_header": {
@@ -4396,7 +4369,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5399194,
+            "created_at": 1718342580.3120933,
             "supported_languages": null
         },
         "macro.dbt.should_full_refresh": {
@@ -4418,7 +4391,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5402334,
+            "created_at": 1718342580.3123076,
             "supported_languages": null
         },
         "macro.dbt.should_store_failures": {
@@ -4440,7 +4413,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.540542,
+            "created_at": 1718342580.312511,
             "supported_languages": null
         },
         "macro.dbt.materialization_test_default": {
@@ -4467,7 +4440,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5431957,
+            "created_at": 1718342580.314438,
             "supported_languages": [
                 "sql"
             ]
@@ -4493,7 +4466,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5436575,
+            "created_at": 1718342580.3153021,
             "supported_languages": null
         },
         "macro.dbt.default__get_test_sql": {
@@ -4515,8 +4488,89 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5439508,
+            "created_at": 1718342580.315511,
             "supported_languages": null
+        },
+        "macro.dbt.get_unit_test_sql": {
+            "name": "get_unit_test_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/helpers.sql",
+            "original_file_path": "macros/materializations/tests/helpers.sql",
+            "unique_id": "macro.dbt.get_unit_test_sql",
+            "macro_sql": "{% macro get_unit_test_sql(main_sql, expected_fixture_sql, expected_column_names) -%}\n  {{ adapter.dispatch('get_unit_test_sql', 'dbt')(main_sql, expected_fixture_sql, expected_column_names) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_unit_test_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.31566,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_unit_test_sql": {
+            "name": "default__get_unit_test_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/helpers.sql",
+            "original_file_path": "macros/materializations/tests/helpers.sql",
+            "unique_id": "macro.dbt.default__get_unit_test_sql",
+            "macro_sql": "{% macro default__get_unit_test_sql(main_sql, expected_fixture_sql, expected_column_names) -%}\n-- Build actual result given inputs\nwith dbt_internal_unit_test_actual as (\n  select\n    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%},{% endif %}{%- endfor -%}, {{ dbt.string_literal(\"actual\") }} as {{ adapter.quote(\"actual_or_expected\") }}\n  from (\n    {{ main_sql }}\n  ) _dbt_internal_unit_test_actual\n),\n-- Build expected result\ndbt_internal_unit_test_expected as (\n  select\n    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%}, {% endif %}{%- endfor -%}, {{ dbt.string_literal(\"expected\") }} as {{ adapter.quote(\"actual_or_expected\") }}\n  from (\n    {{ expected_fixture_sql }}\n  ) _dbt_internal_unit_test_expected\n)\n-- Union actual and expected results\nselect * from dbt_internal_unit_test_actual\nunion all\nselect * from dbt_internal_unit_test_expected\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.string_literal"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.316083,
+            "supported_languages": null
+        },
+        "macro.dbt.materialization_unit_default": {
+            "name": "materialization_unit_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/unit.sql",
+            "original_file_path": "macros/materializations/tests/unit.sql",
+            "unique_id": "macro.dbt.materialization_unit_default",
+            "macro_sql": "{%- materialization unit, default -%}\n\n  {% set relations = [] %}\n\n  {% set expected_rows = config.get('expected_rows') %}\n  {% set expected_sql = config.get('expected_sql') %}\n  {% set tested_expected_column_names = expected_rows[0].keys() if (expected_rows | length ) > 0 else get_columns_in_query(sql) %} %}\n\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {% do run_query(get_create_table_as_sql(True, temp_relation, get_empty_subquery_sql(sql))) %}\n  {%- set columns_in_relation = adapter.get_columns_in_relation(temp_relation) -%}\n  {%- set column_name_to_data_types = {} -%}\n  {%- for column in columns_in_relation -%}\n  {%-   do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n  {%- endfor -%}\n\n  {% if not expected_sql %}\n  {%   set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) %}\n  {% endif %}\n  {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ unit_test_sql }}\n\n  {%- endcall %}\n\n  {% do adapter.drop_relation(temp_relation) %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_columns_in_query",
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.run_query",
+                    "macro.dbt.get_create_table_as_sql",
+                    "macro.dbt.get_empty_subquery_sql",
+                    "macro.dbt.get_expected_sql",
+                    "macro.dbt.get_unit_test_sql",
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.3175333,
+            "supported_languages": [
+                "sql"
+            ]
         },
         "macro.dbt.get_where_subquery": {
             "name": "get_where_subquery",
@@ -4539,7 +4593,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5443087,
+            "created_at": 1718342580.3178751,
             "supported_languages": null
         },
         "macro.dbt.default__get_where_subquery": {
@@ -4561,7 +4615,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5446825,
+            "created_at": 1718342580.3181915,
             "supported_languages": null
         },
         "macro.dbt.create_columns": {
@@ -4585,7 +4639,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.549088,
+            "created_at": 1718342580.3215861,
             "supported_languages": null
         },
         "macro.dbt.default__create_columns": {
@@ -4609,7 +4663,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.54937,
+            "created_at": 1718342580.321788,
             "supported_languages": null
         },
         "macro.dbt.post_snapshot": {
@@ -4633,7 +4687,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5495458,
+            "created_at": 1718342580.321907,
             "supported_languages": null
         },
         "macro.dbt.default__post_snapshot": {
@@ -4655,7 +4709,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.549637,
+            "created_at": 1718342580.3219738,
             "supported_languages": null
         },
         "macro.dbt.get_true_sql": {
@@ -4679,7 +4733,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5497756,
+            "created_at": 1718342580.3221614,
             "supported_languages": null
         },
         "macro.dbt.default__get_true_sql": {
@@ -4701,7 +4755,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5498874,
+            "created_at": 1718342580.322244,
             "supported_languages": null
         },
         "macro.dbt.snapshot_staging_table": {
@@ -4725,7 +4779,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5500886,
+            "created_at": 1718342580.322382,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_staging_table": {
@@ -4749,7 +4803,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5510135,
+            "created_at": 1718342580.323044,
             "supported_languages": null
         },
         "macro.dbt.build_snapshot_table": {
@@ -4773,7 +4827,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5511975,
+            "created_at": 1718342580.3231754,
             "supported_languages": null
         },
         "macro.dbt.default__build_snapshot_table": {
@@ -4795,7 +4849,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5514443,
+            "created_at": 1718342580.3233507,
             "supported_languages": null
         },
         "macro.dbt.build_snapshot_staging_table": {
@@ -4822,7 +4876,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.55188,
+            "created_at": 1718342580.3236485,
             "supported_languages": null
         },
         "macro.dbt.materialization_snapshot_default": {
@@ -4859,7 +4913,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5586557,
+            "created_at": 1718342580.328658,
             "supported_languages": [
                 "sql"
             ]
@@ -4885,7 +4939,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5591733,
+            "created_at": 1718342580.3290915,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_merge_sql": {
@@ -4907,7 +4961,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5594583,
+            "created_at": 1718342580.3293147,
             "supported_languages": null
         },
         "macro.dbt.strategy_dispatch": {
@@ -4929,7 +4983,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.563218,
+            "created_at": 1718342580.3320215,
             "supported_languages": null
         },
         "macro.dbt.snapshot_hash_arguments": {
@@ -4953,7 +5007,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5633988,
+            "created_at": 1718342580.3321457,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_hash_arguments": {
@@ -4975,7 +5029,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5637388,
+            "created_at": 1718342580.3323102,
             "supported_languages": null
         },
         "macro.dbt.snapshot_timestamp_strategy": {
@@ -4999,7 +5053,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5645275,
+            "created_at": 1718342580.332831,
             "supported_languages": null
         },
         "macro.dbt.snapshot_string_as_time": {
@@ -5023,7 +5077,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.564707,
+            "created_at": 1718342580.332951,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_string_as_time": {
@@ -5045,7 +5099,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5648892,
+            "created_at": 1718342580.3331652,
             "supported_languages": null
         },
         "macro.dbt.snapshot_check_all_get_existing_columns": {
@@ -5069,7 +5123,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5663006,
+            "created_at": 1718342580.3342044,
             "supported_languages": null
         },
         "macro.dbt.snapshot_check_strategy": {
@@ -5096,7 +5150,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5675998,
+            "created_at": 1718342580.3354924,
             "supported_languages": null
         },
         "macro.dbt.create_csv_table": {
@@ -5120,7 +5174,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.572908,
+            "created_at": 1718342580.3393958,
             "supported_languages": null
         },
         "macro.dbt.default__create_csv_table": {
@@ -5144,7 +5198,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5737932,
+            "created_at": 1718342580.3400016,
             "supported_languages": null
         },
         "macro.dbt.reset_csv_table": {
@@ -5168,7 +5222,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5740166,
+            "created_at": 1718342580.3401587,
             "supported_languages": null
         },
         "macro.dbt.default__reset_csv_table": {
@@ -5192,7 +5246,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5744674,
+            "created_at": 1718342580.3404777,
             "supported_languages": null
         },
         "macro.dbt.get_csv_sql": {
@@ -5216,7 +5270,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5746727,
+            "created_at": 1718342580.3406224,
             "supported_languages": null
         },
         "macro.dbt.default__get_csv_sql": {
@@ -5238,7 +5292,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.574799,
+            "created_at": 1718342580.340714,
             "supported_languages": null
         },
         "macro.dbt.get_binding_char": {
@@ -5262,7 +5316,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5749333,
+            "created_at": 1718342580.3408084,
             "supported_languages": null
         },
         "macro.dbt.default__get_binding_char": {
@@ -5284,7 +5338,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5750396,
+            "created_at": 1718342580.3408844,
             "supported_languages": null
         },
         "macro.dbt.get_batch_size": {
@@ -5308,7 +5362,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5751874,
+            "created_at": 1718342580.3409917,
             "supported_languages": null
         },
         "macro.dbt.default__get_batch_size": {
@@ -5330,7 +5384,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5752983,
+            "created_at": 1718342580.3410702,
             "supported_languages": null
         },
         "macro.dbt.get_seed_column_quoted_csv": {
@@ -5352,7 +5406,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.575762,
+            "created_at": 1718342580.3413827,
             "supported_languages": null
         },
         "macro.dbt.load_csv_rows": {
@@ -5376,7 +5430,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5759432,
+            "created_at": 1718342580.3415093,
             "supported_languages": null
         },
         "macro.dbt.default__load_csv_rows": {
@@ -5402,7 +5456,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5772634,
+            "created_at": 1718342580.3423326,
             "supported_languages": null
         },
         "macro.dbt.materialization_seed_default": {
@@ -5436,7 +5490,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5807245,
+            "created_at": 1718342580.344582,
             "supported_languages": [
                 "sql"
             ]
@@ -5472,7 +5526,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.583626,
+            "created_at": 1718342580.3466704,
             "supported_languages": [
                 "sql"
             ]
@@ -5507,7 +5561,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5865545,
+            "created_at": 1718342580.34869,
             "supported_languages": [
                 "sql"
             ]
@@ -5540,7 +5594,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5918787,
+            "created_at": 1718342580.3523326,
             "supported_languages": [
                 "sql"
             ]
@@ -5568,7 +5622,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5922709,
+            "created_at": 1718342580.352605,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_teardown": {
@@ -5593,7 +5647,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5925407,
+            "created_at": 1718342580.3527815,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_get_build_sql": {
@@ -5622,7 +5676,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.593817,
+            "created_at": 1718342580.3537242,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_execute_no_op": {
@@ -5644,7 +5698,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5940437,
+            "created_at": 1718342580.3538854,
             "supported_languages": null
         },
         "macro.dbt.materialized_view_execute_build_sql": {
@@ -5672,7 +5726,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.5946872,
+            "created_at": 1718342580.3543181,
             "supported_languages": null
         },
         "macro.dbt.incremental_validate_on_schema_change": {
@@ -5694,7 +5748,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6007638,
+            "created_at": 1718342580.358612,
             "supported_languages": null
         },
         "macro.dbt.check_for_schema_changes": {
@@ -5719,7 +5773,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6020534,
+            "created_at": 1718342580.359635,
             "supported_languages": null
         },
         "macro.dbt.sync_column_schemas": {
@@ -5744,7 +5798,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6033158,
+            "created_at": 1718342580.3606787,
             "supported_languages": null
         },
         "macro.dbt.process_schema_changes": {
@@ -5769,7 +5823,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6042094,
+            "created_at": 1718342580.3613412,
             "supported_languages": null
         },
         "macro.dbt.get_merge_sql": {
@@ -5793,7 +5847,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6113167,
+            "created_at": 1718342580.3666162,
             "supported_languages": null
         },
         "macro.dbt.default__get_merge_sql": {
@@ -5818,7 +5872,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.612972,
+            "created_at": 1718342580.3677595,
             "supported_languages": null
         },
         "macro.dbt.get_delete_insert_merge_sql": {
@@ -5842,7 +5896,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6132426,
+            "created_at": 1718342580.3679504,
             "supported_languages": null
         },
         "macro.dbt.default__get_delete_insert_merge_sql": {
@@ -5866,7 +5920,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.614259,
+            "created_at": 1718342580.3687513,
             "supported_languages": null
         },
         "macro.dbt.get_insert_overwrite_merge_sql": {
@@ -5890,7 +5944,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6145384,
+            "created_at": 1718342580.368945,
             "supported_languages": null
         },
         "macro.dbt.default__get_insert_overwrite_merge_sql": {
@@ -5914,7 +5968,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.615291,
+            "created_at": 1718342580.3695483,
             "supported_languages": null
         },
         "macro.dbt.get_quoted_csv": {
@@ -5936,7 +5990,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6169353,
+            "created_at": 1718342580.370936,
             "supported_languages": null
         },
         "macro.dbt.diff_columns": {
@@ -5958,7 +6012,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6174629,
+            "created_at": 1718342580.371306,
             "supported_languages": null
         },
         "macro.dbt.diff_column_data_types": {
@@ -5980,7 +6034,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6182358,
+            "created_at": 1718342580.37176,
             "supported_languages": null
         },
         "macro.dbt.get_merge_update_columns": {
@@ -6004,7 +6058,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.618634,
+            "created_at": 1718342580.3719199,
             "supported_languages": null
         },
         "macro.dbt.default__get_merge_update_columns": {
@@ -6026,7 +6080,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6195307,
+            "created_at": 1718342580.3724,
             "supported_languages": null
         },
         "macro.dbt.is_incremental": {
@@ -6050,7 +6104,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6202323,
+            "created_at": 1718342580.3728564,
             "supported_languages": null
         },
         "macro.dbt.materialization_incremental_default": {
@@ -6089,7 +6143,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6252937,
+            "created_at": 1718342580.3764365,
             "supported_languages": [
                 "sql"
             ]
@@ -6115,7 +6169,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6262195,
+            "created_at": 1718342580.377127,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_append_sql": {
@@ -6139,7 +6193,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6264565,
+            "created_at": 1718342580.3772814,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_delete_insert_sql": {
@@ -6163,7 +6217,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6266503,
+            "created_at": 1718342580.3774025,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_delete_insert_sql": {
@@ -6187,7 +6241,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6269372,
+            "created_at": 1718342580.3775992,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_merge_sql": {
@@ -6211,7 +6265,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6271317,
+            "created_at": 1718342580.377723,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_merge_sql": {
@@ -6235,7 +6289,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6274204,
+            "created_at": 1718342580.3779154,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_insert_overwrite_sql": {
@@ -6259,7 +6313,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.62761,
+            "created_at": 1718342580.3780475,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_insert_overwrite_sql": {
@@ -6283,7 +6337,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6278706,
+            "created_at": 1718342580.3782184,
             "supported_languages": null
         },
         "macro.dbt.get_incremental_default_sql": {
@@ -6307,7 +6361,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6280508,
+            "created_at": 1718342580.37834,
             "supported_languages": null
         },
         "macro.dbt.default__get_incremental_default_sql": {
@@ -6331,7 +6385,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.628201,
+            "created_at": 1718342580.3784401,
             "supported_languages": null
         },
         "macro.dbt.get_insert_into_sql": {
@@ -6355,7 +6409,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6284833,
+            "created_at": 1718342580.3786352,
             "supported_languages": null
         },
         "macro.dbt.can_clone_table": {
@@ -6379,7 +6433,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6287339,
+            "created_at": 1718342580.3788033,
             "supported_languages": null
         },
         "macro.dbt.default__can_clone_table": {
@@ -6401,7 +6455,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6288488,
+            "created_at": 1718342580.3788884,
             "supported_languages": null
         },
         "macro.dbt.create_or_replace_clone": {
@@ -6425,7 +6479,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6292129,
+            "created_at": 1718342580.3790886,
             "supported_languages": null
         },
         "macro.dbt.default__create_or_replace_clone": {
@@ -6447,7 +6501,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6293995,
+            "created_at": 1718342580.3791878,
             "supported_languages": null
         },
         "macro.dbt.materialization_clone_default": {
@@ -6478,7 +6532,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6333277,
+            "created_at": 1718342580.3822072,
             "supported_languages": [
                 "sql"
             ]
@@ -6504,7 +6558,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6342292,
+            "created_at": 1718342580.3828874,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_sql": {
@@ -6536,7 +6590,53 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6354191,
+            "created_at": 1718342580.38372,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_schema_named": {
+            "name": "drop_schema_named",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/schema.sql",
+            "original_file_path": "macros/relations/schema.sql",
+            "unique_id": "macro.dbt.drop_schema_named",
+            "macro_sql": "{% macro drop_schema_named(schema_name) %}\n    {{ return(adapter.dispatch('drop_schema_named', 'dbt') (schema_name)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__drop_schema_named"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.3839293,
+            "supported_languages": null
+        },
+        "macro.dbt.default__drop_schema_named": {
+            "name": "default__drop_schema_named",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/schema.sql",
+            "original_file_path": "macros/relations/schema.sql",
+            "unique_id": "macro.dbt.default__drop_schema_named",
+            "macro_sql": "{% macro default__drop_schema_named(schema_name) %}\n  {% set schema_relation = api.Relation.create(schema=schema_name) %}\n  {{ adapter.drop_schema(schema_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.3840783,
             "supported_languages": null
         },
         "macro.dbt.get_create_backup_sql": {
@@ -6560,7 +6660,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6358008,
+            "created_at": 1718342580.3843377,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_backup_sql": {
@@ -6586,7 +6686,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6360586,
+            "created_at": 1718342580.3845432,
             "supported_languages": null
         },
         "macro.dbt.get_drop_sql": {
@@ -6610,7 +6710,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6367738,
+            "created_at": 1718342580.3850708,
             "supported_languages": null
         },
         "macro.dbt.default__get_drop_sql": {
@@ -6636,7 +6736,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6371417,
+            "created_at": 1718342580.3853216,
             "supported_languages": null
         },
         "macro.dbt.drop_relation": {
@@ -6660,7 +6760,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6373215,
+            "created_at": 1718342580.385625,
             "supported_languages": null
         },
         "macro.dbt.default__drop_relation": {
@@ -6685,7 +6785,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6375327,
+            "created_at": 1718342580.3858013,
             "supported_languages": null
         },
         "macro.dbt.drop_relation_if_exists": {
@@ -6707,7 +6807,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6377306,
+            "created_at": 1718342580.385953,
             "supported_languages": null
         },
         "macro.dbt.get_rename_sql": {
@@ -6731,7 +6831,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6384318,
+            "created_at": 1718342580.3866253,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_sql": {
@@ -6757,7 +6857,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6388555,
+            "created_at": 1718342580.386954,
             "supported_languages": null
         },
         "macro.dbt.rename_relation": {
@@ -6781,7 +6881,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6390538,
+            "created_at": 1718342580.3871055,
             "supported_languages": null
         },
         "macro.dbt.default__rename_relation": {
@@ -6805,7 +6905,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6393352,
+            "created_at": 1718342580.3873057,
             "supported_languages": null
         },
         "macro.dbt.get_create_intermediate_sql": {
@@ -6829,7 +6929,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6397078,
+            "created_at": 1718342580.3876204,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_intermediate_sql": {
@@ -6855,7 +6955,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6399567,
+            "created_at": 1718342580.3878078,
             "supported_languages": null
         },
         "macro.dbt.get_drop_backup_sql": {
@@ -6879,7 +6979,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.640266,
+            "created_at": 1718342580.388049,
             "supported_languages": null
         },
         "macro.dbt.default__get_drop_backup_sql": {
@@ -6904,7 +7004,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6404645,
+            "created_at": 1718342580.388207,
             "supported_languages": null
         },
         "macro.dbt.get_create_sql": {
@@ -6928,7 +7028,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6409438,
+            "created_at": 1718342580.3885717,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_sql": {
@@ -6954,7 +7054,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6413696,
+            "created_at": 1718342580.3889022,
             "supported_languages": null
         },
         "macro.dbt.get_rename_intermediate_sql": {
@@ -6978,7 +7078,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.641697,
+            "created_at": 1718342580.3891385,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_intermediate_sql": {
@@ -7003,7 +7103,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6418974,
+            "created_at": 1718342580.3892772,
             "supported_languages": null
         },
         "macro.dbt.get_table_columns_and_constraints": {
@@ -7027,7 +7127,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6429393,
+            "created_at": 1718342580.390146,
             "supported_languages": null
         },
         "macro.dbt.default__get_table_columns_and_constraints": {
@@ -7051,7 +7151,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6430545,
+            "created_at": 1718342580.390241,
             "supported_languages": null
         },
         "macro.dbt.table_columns_and_constraints": {
@@ -7073,7 +7173,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6436424,
+            "created_at": 1718342580.3906329,
             "supported_languages": null
         },
         "macro.dbt.get_assert_columns_equivalent": {
@@ -7097,7 +7197,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6438968,
+            "created_at": 1718342580.3907554,
             "supported_languages": null
         },
         "macro.dbt.default__get_assert_columns_equivalent": {
@@ -7121,7 +7221,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.644028,
+            "created_at": 1718342580.3908541,
             "supported_languages": null
         },
         "macro.dbt.assert_columns_equivalent": {
@@ -7147,7 +7247,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6452618,
+            "created_at": 1718342580.3917553,
             "supported_languages": null
         },
         "macro.dbt.format_columns": {
@@ -7171,7 +7271,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6456428,
+            "created_at": 1718342580.3920245,
             "supported_languages": null
         },
         "macro.dbt.default__format_column": {
@@ -7193,7 +7293,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6459916,
+            "created_at": 1718342580.3922553,
             "supported_languages": null
         },
         "macro.dbt.get_replace_view_sql": {
@@ -7217,7 +7317,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6468515,
+            "created_at": 1718342580.3929133,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_view_sql": {
@@ -7239,7 +7339,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6469932,
+            "created_at": 1718342580.3930209,
             "supported_languages": null
         },
         "macro.dbt.create_or_replace_view": {
@@ -7269,7 +7369,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6480694,
+            "created_at": 1718342580.3940003,
             "supported_languages": null
         },
         "macro.dbt.handle_existing_table": {
@@ -7293,7 +7393,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.648259,
+            "created_at": 1718342580.394149,
             "supported_languages": null
         },
         "macro.dbt.default__handle_existing_table": {
@@ -7315,7 +7415,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6484735,
+            "created_at": 1718342580.3943112,
             "supported_languages": null
         },
         "macro.dbt.drop_view": {
@@ -7325,7 +7425,7 @@
             "path": "macros/relations/view/drop.sql",
             "original_file_path": "macros/relations/view/drop.sql",
             "unique_id": "macro.dbt.drop_view",
-            "macro_sql": "{% macro drop_view(relation) -%}\n    {{ return(adapter.dispatch('drop_view', 'dbt')(relation)) }}\n{%- endmacro %}",
+            "macro_sql": "{% macro drop_view(relation) -%}\n    {{- adapter.dispatch('drop_view', 'dbt')(relation) -}}\n{%- endmacro %}",
             "depends_on": {
                 "macros": [
                     "macro.dbt_postgres.postgres__drop_view"
@@ -7339,7 +7439,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6487405,
+            "created_at": 1718342580.3944995,
             "supported_languages": null
         },
         "macro.dbt.default__drop_view": {
@@ -7361,7 +7461,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6488426,
+            "created_at": 1718342580.3945858,
             "supported_languages": null
         },
         "macro.dbt.get_rename_view_sql": {
@@ -7385,7 +7485,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.649106,
+            "created_at": 1718342580.3947809,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_view_sql": {
@@ -7407,7 +7507,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6492453,
+            "created_at": 1718342580.3948836,
             "supported_languages": null
         },
         "macro.dbt.get_create_view_as_sql": {
@@ -7431,7 +7531,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6496537,
+            "created_at": 1718342580.395251,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_view_as_sql": {
@@ -7455,7 +7555,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.649803,
+            "created_at": 1718342580.3954093,
             "supported_languages": null
         },
         "macro.dbt.create_view_as": {
@@ -7479,7 +7579,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6499746,
+            "created_at": 1718342580.3955605,
             "supported_languages": null
         },
         "macro.dbt.default__create_view_as": {
@@ -7503,7 +7603,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6503804,
+            "created_at": 1718342580.3958857,
             "supported_languages": null
         },
         "macro.dbt.get_replace_table_sql": {
@@ -7527,7 +7627,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6506543,
+            "created_at": 1718342580.3960884,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_table_sql": {
@@ -7549,7 +7649,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.650794,
+            "created_at": 1718342580.396198,
             "supported_languages": null
         },
         "macro.dbt.drop_table": {
@@ -7559,7 +7659,7 @@
             "path": "macros/relations/table/drop.sql",
             "original_file_path": "macros/relations/table/drop.sql",
             "unique_id": "macro.dbt.drop_table",
-            "macro_sql": "{% macro drop_table(relation) -%}\n    {{ return(adapter.dispatch('drop_table', 'dbt')(relation)) }}\n{%- endmacro %}",
+            "macro_sql": "{% macro drop_table(relation) -%}\n    {{- adapter.dispatch('drop_table', 'dbt')(relation) -}}\n{%- endmacro %}",
             "depends_on": {
                 "macros": [
                     "macro.dbt_postgres.postgres__drop_table"
@@ -7573,7 +7673,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6510668,
+            "created_at": 1718342580.3963864,
             "supported_languages": null
         },
         "macro.dbt.default__drop_table": {
@@ -7595,7 +7695,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6512222,
+            "created_at": 1718342580.3964798,
             "supported_languages": null
         },
         "macro.dbt.get_rename_table_sql": {
@@ -7619,7 +7719,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.651542,
+            "created_at": 1718342580.3966832,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_table_sql": {
@@ -7641,7 +7741,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6517115,
+            "created_at": 1718342580.3967948,
             "supported_languages": null
         },
         "macro.dbt.get_create_table_as_sql": {
@@ -7665,7 +7765,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6526318,
+            "created_at": 1718342580.3974288,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_table_as_sql": {
@@ -7689,7 +7789,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6528091,
+            "created_at": 1718342580.3975763,
             "supported_languages": null
         },
         "macro.dbt.create_table_as": {
@@ -7713,7 +7813,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6533344,
+            "created_at": 1718342580.3978734,
             "supported_languages": null
         },
         "macro.dbt.default__create_table_as": {
@@ -7739,7 +7839,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.654016,
+            "created_at": 1718342580.3983583,
             "supported_languages": null
         },
         "macro.dbt.default__get_column_names": {
@@ -7761,7 +7861,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6544642,
+            "created_at": 1718342580.398689,
             "supported_languages": null
         },
         "macro.dbt.get_select_subquery": {
@@ -7785,7 +7885,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6546543,
+            "created_at": 1718342580.3988178,
             "supported_languages": null
         },
         "macro.dbt.default__get_select_subquery": {
@@ -7809,7 +7909,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6548293,
+            "created_at": 1718342580.3989472,
             "supported_languages": null
         },
         "macro.dbt.refresh_materialized_view": {
@@ -7833,7 +7933,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6551301,
+            "created_at": 1718342580.3991637,
             "supported_languages": null
         },
         "macro.dbt.default__refresh_materialized_view": {
@@ -7855,7 +7955,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6552625,
+            "created_at": 1718342580.3992572,
             "supported_languages": null
         },
         "macro.dbt.get_replace_materialized_view_sql": {
@@ -7879,7 +7979,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.655537,
+            "created_at": 1718342580.3994532,
             "supported_languages": null
         },
         "macro.dbt.default__get_replace_materialized_view_sql": {
@@ -7901,7 +8001,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6556823,
+            "created_at": 1718342580.3996208,
             "supported_languages": null
         },
         "macro.dbt.drop_materialized_view": {
@@ -7911,7 +8011,7 @@
             "path": "macros/relations/materialized_view/drop.sql",
             "original_file_path": "macros/relations/materialized_view/drop.sql",
             "unique_id": "macro.dbt.drop_materialized_view",
-            "macro_sql": "{% macro drop_materialized_view(relation) -%}\n    {{ return(adapter.dispatch('drop_materialized_view', 'dbt')(relation)) }}\n{%- endmacro %}",
+            "macro_sql": "{% macro drop_materialized_view(relation) -%}\n    {{- adapter.dispatch('drop_materialized_view', 'dbt')(relation) -}}\n{%- endmacro %}",
             "depends_on": {
                 "macros": [
                     "macro.dbt_postgres.postgres__drop_materialized_view"
@@ -7925,7 +8025,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6559346,
+            "created_at": 1718342580.3998442,
             "supported_languages": null
         },
         "macro.dbt.default__drop_materialized_view": {
@@ -7947,7 +8047,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6560376,
+            "created_at": 1718342580.4000444,
             "supported_languages": null
         },
         "macro.dbt.get_rename_materialized_view_sql": {
@@ -7971,7 +8071,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6562972,
+            "created_at": 1718342580.4002557,
             "supported_languages": null
         },
         "macro.dbt.default__get_rename_materialized_view_sql": {
@@ -7993,7 +8093,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.65644,
+            "created_at": 1718342580.400361,
             "supported_languages": null
         },
         "macro.dbt.get_alter_materialized_view_as_sql": {
@@ -8017,7 +8117,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6570497,
+            "created_at": 1718342580.4008403,
             "supported_languages": null
         },
         "macro.dbt.default__get_alter_materialized_view_as_sql": {
@@ -8039,7 +8139,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6572325,
+            "created_at": 1718342580.4009714,
             "supported_languages": null
         },
         "macro.dbt.get_materialized_view_configuration_changes": {
@@ -8063,7 +8163,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6575205,
+            "created_at": 1718342580.4011824,
             "supported_languages": null
         },
         "macro.dbt.default__get_materialized_view_configuration_changes": {
@@ -8085,7 +8185,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6576629,
+            "created_at": 1718342580.4012969,
             "supported_languages": null
         },
         "macro.dbt.get_create_materialized_view_as_sql": {
@@ -8109,7 +8209,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6579247,
+            "created_at": 1718342580.4014933,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_materialized_view_as_sql": {
@@ -8131,7 +8231,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6580632,
+            "created_at": 1718342580.4016087,
             "supported_languages": null
         },
         "macro.dbt.default__test_accepted_values": {
@@ -8153,7 +8253,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6586328,
+            "created_at": 1718342580.402032,
             "supported_languages": null
         },
         "macro.dbt.default__test_not_null": {
@@ -8177,7 +8277,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.658927,
+            "created_at": 1718342580.4022574,
             "supported_languages": null
         },
         "macro.dbt.default__test_relationships": {
@@ -8199,7 +8299,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6592968,
+            "created_at": 1718342580.4025815,
             "supported_languages": null
         },
         "macro.dbt.default__test_unique": {
@@ -8221,7 +8321,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6595511,
+            "created_at": 1718342580.402771,
             "supported_languages": null
         },
         "macro.dbt.listagg": {
@@ -8245,7 +8345,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6601758,
+            "created_at": 1718342580.403408,
             "supported_languages": null
         },
         "macro.dbt.default__listagg": {
@@ -8267,7 +8367,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6605818,
+            "created_at": 1718342580.403729,
             "supported_languages": null
         },
         "macro.dbt.safe_cast": {
@@ -8291,7 +8391,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6608617,
+            "created_at": 1718342580.4039612,
             "supported_languages": null
         },
         "macro.dbt.default__safe_cast": {
@@ -8313,7 +8413,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.661014,
+            "created_at": 1718342580.4040687,
             "supported_languages": null
         },
         "macro.dbt.intersect": {
@@ -8337,7 +8437,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6612434,
+            "created_at": 1718342580.4042351,
             "supported_languages": null
         },
         "macro.dbt.default__intersect": {
@@ -8359,7 +8459,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6613193,
+            "created_at": 1718342580.4042993,
             "supported_languages": null
         },
         "macro.dbt.except": {
@@ -8383,7 +8483,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6617448,
+            "created_at": 1718342580.40446,
             "supported_languages": null
         },
         "macro.dbt.default__except": {
@@ -8405,7 +8505,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.661872,
+            "created_at": 1718342580.4045324,
             "supported_languages": null
         },
         "macro.dbt.get_powers_of_two": {
@@ -8429,7 +8529,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6627808,
+            "created_at": 1718342580.4051785,
             "supported_languages": null
         },
         "macro.dbt.default__get_powers_of_two": {
@@ -8451,7 +8551,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6632087,
+            "created_at": 1718342580.4054904,
             "supported_languages": null
         },
         "macro.dbt.generate_series": {
@@ -8475,7 +8575,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6633935,
+            "created_at": 1718342580.4056432,
             "supported_languages": null
         },
         "macro.dbt.default__generate_series": {
@@ -8499,7 +8599,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6639416,
+            "created_at": 1718342580.4060104,
             "supported_languages": null
         },
         "macro.dbt.replace": {
@@ -8523,7 +8623,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6642861,
+            "created_at": 1718342580.406244,
             "supported_languages": null
         },
         "macro.dbt.default__replace": {
@@ -8545,7 +8645,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.664454,
+            "created_at": 1718342580.4064612,
             "supported_languages": null
         },
         "macro.dbt.get_intervals_between": {
@@ -8569,7 +8669,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6652257,
+            "created_at": 1718342580.407037,
             "supported_languages": null
         },
         "macro.dbt.default__get_intervals_between": {
@@ -8594,7 +8694,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6658232,
+            "created_at": 1718342580.4074483,
             "supported_languages": null
         },
         "macro.dbt.date_spine": {
@@ -8618,7 +8718,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6660545,
+            "created_at": 1718342580.407618,
             "supported_languages": null
         },
         "macro.dbt.default__date_spine": {
@@ -8644,7 +8744,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6664183,
+            "created_at": 1718342580.4078748,
             "supported_languages": null
         },
         "macro.dbt.hash": {
@@ -8668,7 +8768,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6666849,
+            "created_at": 1718342580.4080522,
             "supported_languages": null
         },
         "macro.dbt.default__hash": {
@@ -8690,7 +8790,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6668458,
+            "created_at": 1718342580.4081643,
             "supported_languages": null
         },
         "macro.dbt.concat": {
@@ -8714,7 +8814,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6671133,
+            "created_at": 1718342580.408333,
             "supported_languages": null
         },
         "macro.dbt.default__concat": {
@@ -8736,7 +8836,53 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6672306,
+            "created_at": 1718342580.4084208,
+            "supported_languages": null
+        },
+        "macro.dbt.cast": {
+            "name": "cast",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/cast.sql",
+            "original_file_path": "macros/utils/cast.sql",
+            "unique_id": "macro.dbt.cast",
+            "macro_sql": "{% macro cast(field, type) %}\n  {{ return(adapter.dispatch('cast', 'dbt') (field, type)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__cast"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.4086204,
+            "supported_languages": null
+        },
+        "macro.dbt.default__cast": {
+            "name": "default__cast",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/cast.sql",
+            "original_file_path": "macros/utils/cast.sql",
+            "unique_id": "macro.dbt.default__cast",
+            "macro_sql": "{% macro default__cast(field, type) %}\n    cast({{field}} as {{type}})\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.4087105,
             "supported_languages": null
         },
         "macro.dbt.string_literal": {
@@ -8760,7 +8906,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6675715,
+            "created_at": 1718342580.4088778,
             "supported_languages": null
         },
         "macro.dbt.default__string_literal": {
@@ -8782,7 +8928,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.667697,
+            "created_at": 1718342580.4089541,
             "supported_languages": null
         },
         "macro.dbt.type_string": {
@@ -8806,7 +8952,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6687655,
+            "created_at": 1718342580.4098876,
             "supported_languages": null
         },
         "macro.dbt.default__type_string": {
@@ -8828,7 +8974,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.668916,
+            "created_at": 1718342580.4100478,
             "supported_languages": null
         },
         "macro.dbt.type_timestamp": {
@@ -8852,7 +8998,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6690693,
+            "created_at": 1718342580.410172,
             "supported_languages": null
         },
         "macro.dbt.default__type_timestamp": {
@@ -8874,7 +9020,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.669215,
+            "created_at": 1718342580.410291,
             "supported_languages": null
         },
         "macro.dbt.type_float": {
@@ -8898,7 +9044,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6693678,
+            "created_at": 1718342580.4104068,
             "supported_languages": null
         },
         "macro.dbt.default__type_float": {
@@ -8920,7 +9066,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6695323,
+            "created_at": 1718342580.410532,
             "supported_languages": null
         },
         "macro.dbt.type_numeric": {
@@ -8944,7 +9090,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6696868,
+            "created_at": 1718342580.410649,
             "supported_languages": null
         },
         "macro.dbt.default__type_numeric": {
@@ -8966,7 +9112,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6698532,
+            "created_at": 1718342580.410781,
             "supported_languages": null
         },
         "macro.dbt.type_bigint": {
@@ -8990,7 +9136,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6700027,
+            "created_at": 1718342580.4108956,
             "supported_languages": null
         },
         "macro.dbt.default__type_bigint": {
@@ -9012,7 +9158,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6702461,
+            "created_at": 1718342580.4110038,
             "supported_languages": null
         },
         "macro.dbt.type_int": {
@@ -9036,7 +9182,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.670405,
+            "created_at": 1718342580.4111238,
             "supported_languages": null
         },
         "macro.dbt.default__type_int": {
@@ -9058,7 +9204,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.670555,
+            "created_at": 1718342580.4112356,
             "supported_languages": null
         },
         "macro.dbt.type_boolean": {
@@ -9082,7 +9228,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6707082,
+            "created_at": 1718342580.411347,
             "supported_languages": null
         },
         "macro.dbt.default__type_boolean": {
@@ -9104,7 +9250,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6708455,
+            "created_at": 1718342580.4116066,
             "supported_languages": null
         },
         "macro.dbt.array_construct": {
@@ -9128,7 +9274,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6712036,
+            "created_at": 1718342580.4119425,
             "supported_languages": null
         },
         "macro.dbt.default__array_construct": {
@@ -9150,7 +9296,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6714365,
+            "created_at": 1718342580.4121304,
             "supported_languages": null
         },
         "macro.dbt.cast_bool_to_text": {
@@ -9174,7 +9320,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6717927,
+            "created_at": 1718342580.4123318,
             "supported_languages": null
         },
         "macro.dbt.default__cast_bool_to_text": {
@@ -9196,7 +9342,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.671995,
+            "created_at": 1718342580.4124503,
             "supported_languages": null
         },
         "macro.dbt.bool_or": {
@@ -9220,7 +9366,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6722603,
+            "created_at": 1718342580.4126403,
             "supported_languages": null
         },
         "macro.dbt.default__bool_or": {
@@ -9242,7 +9388,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6723726,
+            "created_at": 1718342580.4127219,
             "supported_languages": null
         },
         "macro.dbt.dateadd": {
@@ -9266,7 +9412,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6727378,
+            "created_at": 1718342580.412981,
             "supported_languages": null
         },
         "macro.dbt.default__dateadd": {
@@ -9288,7 +9434,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6729088,
+            "created_at": 1718342580.4131012,
             "supported_languages": null
         },
         "macro.dbt.any_value": {
@@ -9312,7 +9458,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.673148,
+            "created_at": 1718342580.413281,
             "supported_languages": null
         },
         "macro.dbt.default__any_value": {
@@ -9334,7 +9480,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6732557,
+            "created_at": 1718342580.4133542,
             "supported_languages": null
         },
         "macro.dbt.split_part": {
@@ -9358,7 +9504,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6738064,
+            "created_at": 1718342580.4137516,
             "supported_languages": null
         },
         "macro.dbt.default__split_part": {
@@ -9380,7 +9526,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.673971,
+            "created_at": 1718342580.4138653,
             "supported_languages": null
         },
         "macro.dbt._split_part_negative": {
@@ -9402,7 +9548,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6741853,
+            "created_at": 1718342580.4140205,
             "supported_languages": null
         },
         "macro.dbt.length": {
@@ -9426,7 +9572,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.674433,
+            "created_at": 1718342580.414194,
             "supported_languages": null
         },
         "macro.dbt.default__length": {
@@ -9448,7 +9594,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6745496,
+            "created_at": 1718342580.4142718,
             "supported_languages": null
         },
         "macro.dbt.right": {
@@ -9472,7 +9618,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6748302,
+            "created_at": 1718342580.414477,
             "supported_languages": null
         },
         "macro.dbt.default__right": {
@@ -9494,7 +9640,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6749709,
+            "created_at": 1718342580.414587,
             "supported_languages": null
         },
         "macro.dbt.position": {
@@ -9518,7 +9664,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6752727,
+            "created_at": 1718342580.4147823,
             "supported_languages": null
         },
         "macro.dbt.default__position": {
@@ -9540,7 +9686,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.675453,
+            "created_at": 1718342580.4148755,
             "supported_languages": null
         },
         "macro.dbt.date_trunc": {
@@ -9564,7 +9710,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6757562,
+            "created_at": 1718342580.4150612,
             "supported_languages": null
         },
         "macro.dbt.default__date_trunc": {
@@ -9586,7 +9732,53 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6758823,
+            "created_at": 1718342580.4151547,
+            "supported_languages": null
+        },
+        "macro.dbt.date": {
+            "name": "date",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date.sql",
+            "original_file_path": "macros/utils/date.sql",
+            "unique_id": "macro.dbt.date",
+            "macro_sql": "{% macro date(year, month, day) %}\n  {{ return(adapter.dispatch('date', 'dbt') (year, month, day)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__date"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.4153864,
+            "supported_languages": null
+        },
+        "macro.dbt.default__date": {
+            "name": "default__date",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date.sql",
+            "original_file_path": "macros/utils/date.sql",
+            "unique_id": "macro.dbt.default__date",
+            "macro_sql": "{% macro default__date(year, month, day) -%}\n    {%- set dt = modules.datetime.date(year, month, day) -%}\n    {%- set iso_8601_formatted_date = dt.strftime('%Y-%m-%d') -%}\n    to_date('{{ iso_8601_formatted_date }}', 'YYYY-MM-DD')\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.4155967,
             "supported_languages": null
         },
         "macro.dbt.last_day": {
@@ -9610,7 +9802,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.676216,
+            "created_at": 1718342580.4158368,
             "supported_languages": null
         },
         "macro.dbt.default_last_day": {
@@ -9635,7 +9827,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.676614,
+            "created_at": 1718342580.4160984,
             "supported_languages": null
         },
         "macro.dbt.default__last_day": {
@@ -9659,7 +9851,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6767573,
+            "created_at": 1718342580.4162023,
             "supported_languages": null
         },
         "macro.dbt.escape_single_quotes": {
@@ -9683,7 +9875,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6770108,
+            "created_at": 1718342580.4163883,
             "supported_languages": null
         },
         "macro.dbt.default__escape_single_quotes": {
@@ -9705,7 +9897,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6771474,
+            "created_at": 1718342580.4164913,
             "supported_languages": null
         },
         "macro.dbt.datediff": {
@@ -9729,7 +9921,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.677466,
+            "created_at": 1718342580.4167254,
             "supported_languages": null
         },
         "macro.dbt.default__datediff": {
@@ -9751,7 +9943,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6776445,
+            "created_at": 1718342580.4168377,
             "supported_languages": null
         },
         "macro.dbt.array_append": {
@@ -9775,7 +9967,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6779194,
+            "created_at": 1718342580.417031,
             "supported_languages": null
         },
         "macro.dbt.default__array_append": {
@@ -9797,7 +9989,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.678047,
+            "created_at": 1718342580.4171221,
             "supported_languages": null
         },
         "macro.dbt.array_concat": {
@@ -9821,7 +10013,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6783056,
+            "created_at": 1718342580.4173093,
             "supported_languages": null
         },
         "macro.dbt.default__array_concat": {
@@ -9843,7 +10035,83 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.678443,
+            "created_at": 1718342580.417401,
+            "supported_languages": null
+        },
+        "macro.dbt.get_fixture_sql": {
+            "name": "get_fixture_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "unique_id": "macro.dbt.get_fixture_sql",
+            "macro_sql": "{% macro get_fixture_sql(rows, column_name_to_data_types) %}\n-- Fixture for {{ model.name }}\n{% set default_row = {} %}\n\n{%- if not column_name_to_data_types -%}\n{#-- Use defer_relation IFF it is available in the manifest and 'this' is missing from the database --#}\n{%-   set this_or_defer_relation = defer_relation if (defer_relation and not load_relation(this)) else this -%}\n{%-   set columns_in_relation = adapter.get_columns_in_relation(this_or_defer_relation) -%}\n\n{%-   set column_name_to_data_types = {} -%}\n{%-   for column in columns_in_relation -%}\n{#-- This needs to be a case-insensitive comparison --#}\n{%-     do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n{%-   endfor -%}\n{%- endif -%}\n\n{%- if not column_name_to_data_types -%}\n    {{ exceptions.raise_compiler_error(\"Not able to get columns for unit test '\" ~ model.name ~ \"' from relation \" ~ this ~ \" because the relation doesn't exist\") }}\n{%- endif -%}\n\n{%- for column_name, column_type in column_name_to_data_types.items() -%}\n    {%- do default_row.update({column_name: (safe_cast(\"null\", column_type) | trim )}) -%}\n{%- endfor -%}\n\n\n{%- for row in rows -%}\n{%-   set formatted_row = format_row(row, column_name_to_data_types) -%}\n{%-   set default_row_copy = default_row.copy() -%}\n{%-   do default_row_copy.update(formatted_row) -%}\nselect\n{%-   for column_name, column_value in default_row_copy.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%}, {%- endif %}\n{%-   endfor %}\n{%-   if not loop.last %}\nunion all\n{%    endif %}\n{%- endfor -%}\n\n{%- if (rows | length) == 0 -%}\n    select\n    {%- for column_name, column_value in default_row.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%},{%- endif %}\n    {%- endfor %}\n    limit 0\n{%- endif -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_relation",
+                    "macro.dbt.safe_cast",
+                    "macro.dbt.format_row"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.420144,
+            "supported_languages": null
+        },
+        "macro.dbt.get_expected_sql": {
+            "name": "get_expected_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "unique_id": "macro.dbt.get_expected_sql",
+            "macro_sql": "{% macro get_expected_sql(rows, column_name_to_data_types) %}\n\n{%- if (rows | length) == 0 -%}\n    select * from dbt_internal_unit_test_actual\n    limit 0\n{%- else -%}\n{%- for row in rows -%}\n{%- set formatted_row = format_row(row, column_name_to_data_types) -%}\nselect\n{%- for column_name, column_value in formatted_row.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%}, {%- endif %}\n{%- endfor %}\n{%- if not loop.last %}\nunion all\n{% endif %}\n{%- endfor -%}\n{%- endif -%}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.format_row"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.420575,
+            "supported_languages": null
+        },
+        "macro.dbt.format_row": {
+            "name": "format_row",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "unique_id": "macro.dbt.format_row",
+            "macro_sql": "\n\n{%- macro format_row(row, column_name_to_data_types) -%}\n    {#-- generate case-insensitive formatted row --#}\n    {% set formatted_row = {} %}\n    {%- for column_name, column_value in row.items() -%}\n        {% set column_name = column_name|lower %}\n\n        {%- if column_name not in column_name_to_data_types %}\n            {#-- if user-provided row contains column name that relation does not contain, raise an error --#}\n            {% set fixture_name = \"expected output\" if model.resource_type == 'unit_test' else (\"'\" ~ model.name ~ \"'\") %}\n            {{ exceptions.raise_compiler_error(\n                \"Invalid column name: '\" ~ column_name ~ \"' in unit test fixture for \" ~ fixture_name ~ \".\"\n                \"\\nAccepted columns for \" ~ fixture_name ~ \" are: \" ~ (column_name_to_data_types.keys()|list)\n            ) }}\n        {%- endif -%}\n\n        {%- set column_type = column_name_to_data_types[column_name] %}\n\n        {#-- sanitize column_value: wrap yaml strings in quotes, apply cast --#}\n        {%- set column_value_clean = column_value -%}\n        {%- if column_value is string -%}\n            {%- set column_value_clean = dbt.string_literal(dbt.escape_single_quotes(column_value)) -%}\n        {%- elif column_value is none -%}\n            {%- set column_value_clean = 'null' -%}\n        {%- endif -%}\n\n        {%- set row_update = {column_name: safe_cast(column_value_clean, column_type) } -%}\n        {%- do formatted_row.update(row_update) -%}\n    {%- endfor -%}\n    {{ return(formatted_row) }}\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.string_literal",
+                    "macro.dbt.escape_single_quotes",
+                    "macro.dbt.safe_cast"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1718342580.42135,
             "supported_languages": null
         },
         "macro.dbt.convert_datetime": {
@@ -9865,7 +10133,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.680482,
+            "created_at": 1718342580.4227633,
             "supported_languages": null
         },
         "macro.dbt.dates_in_range": {
@@ -9889,7 +10157,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6818788,
+            "created_at": 1718342580.423555,
             "supported_languages": null
         },
         "macro.dbt.partition_range": {
@@ -9913,7 +10181,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6826746,
+            "created_at": 1718342580.4240794,
             "supported_languages": null
         },
         "macro.dbt.py_current_timestring": {
@@ -9935,7 +10203,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6829095,
+            "created_at": 1718342580.4242406,
             "supported_languages": null
         },
         "macro.dbt.statement": {
@@ -9957,7 +10225,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6844487,
+            "created_at": 1718342580.4252777,
             "supported_languages": null
         },
         "macro.dbt.noop_statement": {
@@ -9979,7 +10247,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6850069,
+            "created_at": 1718342580.4256752,
             "supported_languages": null
         },
         "macro.dbt.run_query": {
@@ -10003,7 +10271,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6852882,
+            "created_at": 1718342580.4258752,
             "supported_languages": null
         },
         "macro.dbt.current_timestamp": {
@@ -10027,7 +10295,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6857924,
+            "created_at": 1718342580.4262376,
             "supported_languages": null
         },
         "macro.dbt.default__current_timestamp": {
@@ -10049,7 +10317,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6859424,
+            "created_at": 1718342580.4263422,
             "supported_languages": null
         },
         "macro.dbt.snapshot_get_time": {
@@ -10073,7 +10341,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6860795,
+            "created_at": 1718342580.4264402,
             "supported_languages": null
         },
         "macro.dbt.default__snapshot_get_time": {
@@ -10097,7 +10365,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6861804,
+            "created_at": 1718342580.4265125,
             "supported_languages": null
         },
         "macro.dbt.current_timestamp_backcompat": {
@@ -10121,7 +10389,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.686342,
+            "created_at": 1718342580.4266527,
             "supported_languages": null
         },
         "macro.dbt.default__current_timestamp_backcompat": {
@@ -10143,7 +10411,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.686416,
+            "created_at": 1718342580.4267845,
             "supported_languages": null
         },
         "macro.dbt.current_timestamp_in_utc_backcompat": {
@@ -10167,7 +10435,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.686591,
+            "created_at": 1718342580.4268987,
             "supported_languages": null
         },
         "macro.dbt.default__current_timestamp_in_utc_backcompat": {
@@ -10192,7 +10460,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.686751,
+            "created_at": 1718342580.4270122,
             "supported_languages": null
         },
         "macro.dbt.create_schema": {
@@ -10216,7 +10484,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6871312,
+            "created_at": 1718342580.4272735,
             "supported_languages": null
         },
         "macro.dbt.default__create_schema": {
@@ -10240,7 +10508,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6873097,
+            "created_at": 1718342580.427396,
             "supported_languages": null
         },
         "macro.dbt.drop_schema": {
@@ -10264,7 +10532,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6874635,
+            "created_at": 1718342580.4275029,
             "supported_languages": null
         },
         "macro.dbt.default__drop_schema": {
@@ -10288,7 +10556,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.687781,
+            "created_at": 1718342580.4276319,
             "supported_languages": null
         },
         "macro.dbt.alter_column_comment": {
@@ -10312,7 +10580,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6884515,
+            "created_at": 1718342580.4281182,
             "supported_languages": null
         },
         "macro.dbt.default__alter_column_comment": {
@@ -10334,7 +10602,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6886406,
+            "created_at": 1718342580.428232,
             "supported_languages": null
         },
         "macro.dbt.alter_relation_comment": {
@@ -10358,7 +10626,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6888337,
+            "created_at": 1718342580.428367,
             "supported_languages": null
         },
         "macro.dbt.default__alter_relation_comment": {
@@ -10380,7 +10648,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.689002,
+            "created_at": 1718342580.4285026,
             "supported_languages": null
         },
         "macro.dbt.persist_docs": {
@@ -10404,7 +10672,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6893237,
+            "created_at": 1718342580.428688,
             "supported_languages": null
         },
         "macro.dbt.default__persist_docs": {
@@ -10430,7 +10698,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6899436,
+            "created_at": 1718342580.4290164,
             "supported_languages": null
         },
         "macro.dbt.get_show_sql": {
@@ -10454,7 +10722,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6905391,
+            "created_at": 1718342580.4293878,
             "supported_languages": null
         },
         "macro.dbt.get_limit_subquery_sql": {
@@ -10478,7 +10746,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.690736,
+            "created_at": 1718342580.4295487,
             "supported_languages": null
         },
         "macro.dbt.default__get_limit_subquery_sql": {
@@ -10500,7 +10768,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6908708,
+            "created_at": 1718342580.4296458,
             "supported_languages": null
         },
         "macro.dbt.get_catalog_relations": {
@@ -10524,7 +10792,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6937242,
+            "created_at": 1718342580.4320412,
             "supported_languages": null
         },
         "macro.dbt.default__get_catalog_relations": {
@@ -10546,7 +10814,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6939764,
+            "created_at": 1718342580.432248,
             "supported_languages": null
         },
         "macro.dbt.get_catalog": {
@@ -10570,7 +10838,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6941724,
+            "created_at": 1718342580.432404,
             "supported_languages": null
         },
         "macro.dbt.default__get_catalog": {
@@ -10592,7 +10860,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6944196,
+            "created_at": 1718342580.4325964,
             "supported_languages": null
         },
         "macro.dbt.information_schema_name": {
@@ -10616,7 +10884,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6946058,
+            "created_at": 1718342580.4327369,
             "supported_languages": null
         },
         "macro.dbt.default__information_schema_name": {
@@ -10638,7 +10906,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6947546,
+            "created_at": 1718342580.4328551,
             "supported_languages": null
         },
         "macro.dbt.list_schemas": {
@@ -10662,7 +10930,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6949258,
+            "created_at": 1718342580.4329782,
             "supported_languages": null
         },
         "macro.dbt.default__list_schemas": {
@@ -10687,7 +10955,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6951747,
+            "created_at": 1718342580.4331527,
             "supported_languages": null
         },
         "macro.dbt.check_schema_exists": {
@@ -10711,7 +10979,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.695369,
+            "created_at": 1718342580.4332967,
             "supported_languages": null
         },
         "macro.dbt.default__check_schema_exists": {
@@ -10736,7 +11004,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6956708,
+            "created_at": 1718342580.433508,
             "supported_languages": null
         },
         "macro.dbt.list_relations_without_caching": {
@@ -10760,7 +11028,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.69585,
+            "created_at": 1718342580.4337533,
             "supported_languages": null
         },
         "macro.dbt.default__list_relations_without_caching": {
@@ -10782,7 +11050,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6960087,
+            "created_at": 1718342580.4338777,
             "supported_languages": null
         },
         "macro.dbt.get_relations": {
@@ -10806,7 +11074,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6961653,
+            "created_at": 1718342580.4340005,
             "supported_languages": null
         },
         "macro.dbt.default__get_relations": {
@@ -10828,7 +11096,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6963146,
+            "created_at": 1718342580.4341094,
             "supported_languages": null
         },
         "macro.dbt.get_relation_last_modified": {
@@ -10852,7 +11120,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6965284,
+            "created_at": 1718342580.434242,
             "supported_languages": null
         },
         "macro.dbt.default__get_relation_last_modified": {
@@ -10874,7 +11142,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6967025,
+            "created_at": 1718342580.4343593,
             "supported_languages": null
         },
         "macro.dbt.validate_sql": {
@@ -10898,7 +11166,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6969883,
+            "created_at": 1718342580.4345875,
             "supported_languages": null
         },
         "macro.dbt.default__validate_sql": {
@@ -10922,7 +11190,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6973152,
+            "created_at": 1718342580.4347458,
             "supported_languages": null
         },
         "macro.dbt.make_intermediate_relation": {
@@ -10946,7 +11214,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6996481,
+            "created_at": 1718342580.4366345,
             "supported_languages": null
         },
         "macro.dbt.default__make_intermediate_relation": {
@@ -10970,7 +11238,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.6998343,
+            "created_at": 1718342580.4367592,
             "supported_languages": null
         },
         "macro.dbt.make_temp_relation": {
@@ -10994,7 +11262,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7000697,
+            "created_at": 1718342580.436917,
             "supported_languages": null
         },
         "macro.dbt.default__make_temp_relation": {
@@ -11016,7 +11284,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.700396,
+            "created_at": 1718342580.4371402,
             "supported_languages": null
         },
         "macro.dbt.make_backup_relation": {
@@ -11040,7 +11308,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7006702,
+            "created_at": 1718342580.437321,
             "supported_languages": null
         },
         "macro.dbt.default__make_backup_relation": {
@@ -11062,7 +11330,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7010062,
+            "created_at": 1718342580.4375682,
             "supported_languages": null
         },
         "macro.dbt.truncate_relation": {
@@ -11086,7 +11354,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7011907,
+            "created_at": 1718342580.4376957,
             "supported_languages": null
         },
         "macro.dbt.default__truncate_relation": {
@@ -11110,7 +11378,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.701359,
+            "created_at": 1718342580.4378111,
             "supported_languages": null
         },
         "macro.dbt.get_or_create_relation": {
@@ -11134,7 +11402,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.701628,
+            "created_at": 1718342580.4379826,
             "supported_languages": null
         },
         "macro.dbt.default__get_or_create_relation": {
@@ -11156,7 +11424,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7022717,
+            "created_at": 1718342580.4383667,
             "supported_languages": null
         },
         "macro.dbt.load_cached_relation": {
@@ -11178,7 +11446,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7025523,
+            "created_at": 1718342580.4385493,
             "supported_languages": null
         },
         "macro.dbt.load_relation": {
@@ -11202,7 +11470,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7026973,
+            "created_at": 1718342580.4386542,
             "supported_languages": null
         },
         "macro.dbt.get_create_index_sql": {
@@ -11226,7 +11494,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.703569,
+            "created_at": 1718342580.4392934,
             "supported_languages": null
         },
         "macro.dbt.default__get_create_index_sql": {
@@ -11248,7 +11516,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7037008,
+            "created_at": 1718342580.439387,
             "supported_languages": null
         },
         "macro.dbt.create_indexes": {
@@ -11272,7 +11540,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.703851,
+            "created_at": 1718342580.4394984,
             "supported_languages": null
         },
         "macro.dbt.default__create_indexes": {
@@ -11297,7 +11565,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7042568,
+            "created_at": 1718342580.4397836,
             "supported_languages": null
         },
         "macro.dbt.get_drop_index_sql": {
@@ -11321,7 +11589,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7044408,
+            "created_at": 1718342580.4400208,
             "supported_languages": null
         },
         "macro.dbt.default__get_drop_index_sql": {
@@ -11343,7 +11611,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.704594,
+            "created_at": 1718342580.4401512,
             "supported_languages": null
         },
         "macro.dbt.get_show_indexes_sql": {
@@ -11367,7 +11635,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7047448,
+            "created_at": 1718342580.4402647,
             "supported_languages": null
         },
         "macro.dbt.default__get_show_indexes_sql": {
@@ -11389,7 +11657,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7048671,
+            "created_at": 1718342580.4403596,
             "supported_languages": null
         },
         "macro.dbt.collect_freshness": {
@@ -11413,7 +11681,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7052772,
+            "created_at": 1718342580.4408116,
             "supported_languages": null
         },
         "macro.dbt.default__collect_freshness": {
@@ -11438,7 +11706,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7057054,
+            "created_at": 1718342580.4411116,
             "supported_languages": null
         },
         "macro.dbt.copy_grants": {
@@ -11462,7 +11730,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7075596,
+            "created_at": 1718342580.442436,
             "supported_languages": null
         },
         "macro.dbt.default__copy_grants": {
@@ -11484,7 +11752,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.70769,
+            "created_at": 1718342580.442533,
             "supported_languages": null
         },
         "macro.dbt.support_multiple_grantees_per_dcl_statement": {
@@ -11508,7 +11776,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7078502,
+            "created_at": 1718342580.4426484,
             "supported_languages": null
         },
         "macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
@@ -11530,7 +11798,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7079563,
+            "created_at": 1718342580.4427257,
             "supported_languages": null
         },
         "macro.dbt.should_revoke": {
@@ -11554,7 +11822,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.708632,
+            "created_at": 1718342580.4429762,
             "supported_languages": null
         },
         "macro.dbt.get_show_grant_sql": {
@@ -11578,7 +11846,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7088225,
+            "created_at": 1718342580.4431021,
             "supported_languages": null
         },
         "macro.dbt.default__get_show_grant_sql": {
@@ -11600,7 +11868,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7089264,
+            "created_at": 1718342580.4431777,
             "supported_languages": null
         },
         "macro.dbt.get_grant_sql": {
@@ -11624,7 +11892,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7091422,
+            "created_at": 1718342580.4433708,
             "supported_languages": null
         },
         "macro.dbt.default__get_grant_sql": {
@@ -11646,7 +11914,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7094028,
+            "created_at": 1718342580.443533,
             "supported_languages": null
         },
         "macro.dbt.get_revoke_sql": {
@@ -11670,7 +11938,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7096798,
+            "created_at": 1718342580.443699,
             "supported_languages": null
         },
         "macro.dbt.default__get_revoke_sql": {
@@ -11692,7 +11960,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7098777,
+            "created_at": 1718342580.443834,
             "supported_languages": null
         },
         "macro.dbt.get_dcl_statement_list": {
@@ -11716,7 +11984,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7101038,
+            "created_at": 1718342580.4439936,
             "supported_languages": null
         },
         "macro.dbt.default__get_dcl_statement_list": {
@@ -11740,7 +12008,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7108228,
+            "created_at": 1718342580.4444935,
             "supported_languages": null
         },
         "macro.dbt.call_dcl_statements": {
@@ -11764,7 +12032,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7110174,
+            "created_at": 1718342580.4446437,
             "supported_languages": null
         },
         "macro.dbt.default__call_dcl_statements": {
@@ -11788,7 +12056,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7112856,
+            "created_at": 1718342580.4448314,
             "supported_languages": null
         },
         "macro.dbt.apply_grants": {
@@ -11812,7 +12080,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7115273,
+            "created_at": 1718342580.4451659,
             "supported_languages": null
         },
         "macro.dbt.default__apply_grants": {
@@ -11839,7 +12107,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7127564,
+            "created_at": 1718342580.446021,
             "supported_languages": null
         },
         "macro.dbt.get_columns_in_relation": {
@@ -11863,7 +12131,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.715107,
+            "created_at": 1718342580.447782,
             "supported_languages": null
         },
         "macro.dbt.default__get_columns_in_relation": {
@@ -11885,7 +12153,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.715303,
+            "created_at": 1718342580.4478931,
             "supported_languages": null
         },
         "macro.dbt.sql_convert_columns_in_relation": {
@@ -11907,7 +12175,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7156436,
+            "created_at": 1718342580.4481127,
             "supported_languages": null
         },
         "macro.dbt.get_empty_subquery_sql": {
@@ -11931,7 +12199,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7158732,
+            "created_at": 1718342580.4482665,
             "supported_languages": null
         },
         "macro.dbt.default__get_empty_subquery_sql": {
@@ -11953,7 +12221,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7160895,
+            "created_at": 1718342580.4484205,
             "supported_languages": null
         },
         "macro.dbt.get_empty_schema_sql": {
@@ -11977,7 +12245,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.716269,
+            "created_at": 1718342580.4485488,
             "supported_languages": null
         },
         "macro.dbt.default__get_empty_schema_sql": {
@@ -11987,9 +12255,11 @@
             "path": "macros/adapters/columns.sql",
             "original_file_path": "macros/adapters/columns.sql",
             "unique_id": "macro.dbt.default__get_empty_schema_sql",
-            "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    {%- set col_naked_numeric = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {%- do col_err.append(col['name']) -%}\n      {#-- If this column's type is just 'numeric' then it is missing precision/scale, raise a warning --#}\n      {%- elif col['data_type'].strip().lower() in ('numeric', 'decimal', 'number') -%}\n        {%- do col_naked_numeric.append(col['name']) -%}\n      {%- endif -%}\n      {% set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] %}\n      cast(null as {{ col['data_type'] }}) as {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- elif (col_naked_numeric | length) > 0 -%}\n      {{ exceptions.warn(\"Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: \" ~ col_naked_numeric ~ \"`\") }}\n    {%- endif -%}\n{% endmacro %}",
+            "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    {%- set col_naked_numeric = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {%- do col_err.append(col['name']) -%}\n      {#-- If this column's type is just 'numeric' then it is missing precision/scale, raise a warning --#}\n      {%- elif col['data_type'].strip().lower() in ('numeric', 'decimal', 'number') -%}\n        {%- do col_naked_numeric.append(col['name']) -%}\n      {%- endif -%}\n      {% set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] %}\n      {{ cast('null', col['data_type']) }} as {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- elif (col_naked_numeric | length) > 0 -%}\n      {{ exceptions.warn(\"Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: \" ~ col_naked_numeric ~ \"`\") }}\n    {%- endif -%}\n{% endmacro %}",
             "depends_on": {
-                "macros": []
+                "macros": [
+                    "macro.dbt.cast"
+                ]
             },
             "description": "",
             "meta": {},
@@ -11999,7 +12269,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7174451,
+            "created_at": 1718342580.4496489,
             "supported_languages": null
         },
         "macro.dbt.get_column_schema_from_query": {
@@ -12023,7 +12293,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7178178,
+            "created_at": 1718342580.4498816,
             "supported_languages": null
         },
         "macro.dbt.get_columns_in_query": {
@@ -12047,7 +12317,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7180011,
+            "created_at": 1718342580.450087,
             "supported_languages": null
         },
         "macro.dbt.default__get_columns_in_query": {
@@ -12072,7 +12342,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7183414,
+            "created_at": 1718342580.4503593,
             "supported_languages": null
         },
         "macro.dbt.alter_column_type": {
@@ -12096,7 +12366,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7185905,
+            "created_at": 1718342580.450553,
             "supported_languages": null
         },
         "macro.dbt.default__alter_column_type": {
@@ -12120,7 +12390,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7191694,
+            "created_at": 1718342580.4509845,
             "supported_languages": null
         },
         "macro.dbt.alter_relation_add_remove_columns": {
@@ -12144,7 +12414,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7194304,
+            "created_at": 1718342580.4511735,
             "supported_languages": null
         },
         "macro.dbt.default__alter_relation_add_remove_columns": {
@@ -12168,7 +12438,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.753678,
+            "created_at": 1718342580.4517665,
             "supported_languages": null
         },
         "macro.dbt.test_unique": {
@@ -12192,7 +12462,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.754263,
+            "created_at": 1718342580.4521935,
             "supported_languages": null
         },
         "macro.dbt.test_not_null": {
@@ -12216,7 +12486,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7545114,
+            "created_at": 1718342580.452389,
             "supported_languages": null
         },
         "macro.dbt.test_accepted_values": {
@@ -12240,7 +12510,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7547958,
+            "created_at": 1718342580.4527092,
             "supported_languages": null
         },
         "macro.dbt.test_relationships": {
@@ -12264,7 +12534,7 @@
             },
             "patch_path": null,
             "arguments": [],
-            "created_at": 1708330298.7550614,
+            "created_at": 1718342580.4529166,
             "supported_languages": null
         }
     },
@@ -12279,140 +12549,7 @@
             "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--select` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/introduction)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [dbt Community](https://www.getdbt.com/community/) for questions and discussion"
         }
     },
-    "exposures": {
-        "exposure.sandbox.clients": {
-            "name": "clients",
-            "resource_type": "exposure",
-            "package_name": "sandbox",
-            "path": "exposures/our_analytics.yml",
-            "original_file_path": "models/exposures/our_analytics.yml",
-            "unique_id": "exposure.sandbox.clients",
-            "fqn": [
-                "sandbox",
-                "exposures",
-                "clients"
-            ],
-            "type": "analysis",
-            "owner": {
-                "email": "dbtmetabase@example.com",
-                "name": "dbtmetabase"
-            },
-            "description": "### Visualization: Table\n\nNo description provided in Metabase\n\n#### Metadata\n\nMetabase ID: __3__\n\nCreated On: __2024-02-19T03:48:22.030934__",
-            "label": "clients",
-            "maturity": "medium",
-            "meta": {},
-            "tags": [],
-            "config": {
-                "enabled": true
-            },
-            "unrendered_config": {},
-            "url": "http://localhost:3000/card/3",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "model.sandbox.customers"
-                ]
-            },
-            "refs": [
-                {
-                    "name": "customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "created_at": 1708330299.1868012
-        },
-        "exposure.sandbox.customers": {
-            "name": "customers",
-            "resource_type": "exposure",
-            "package_name": "sandbox",
-            "path": "exposures/our_analytics.yml",
-            "original_file_path": "models/exposures/our_analytics.yml",
-            "unique_id": "exposure.sandbox.customers",
-            "fqn": [
-                "sandbox",
-                "exposures",
-                "customers"
-            ],
-            "type": "analysis",
-            "owner": {
-                "email": "dbtmetabase@example.com",
-                "name": "dbtmetabase"
-            },
-            "description": "### Visualization: Line\n\nCustomers test\n\n#### Metadata\n\nMetabase ID: __1__\n\nCreated On: __2024-02-19T03:42:12.127181__",
-            "label": "Customers",
-            "maturity": "medium",
-            "meta": {},
-            "tags": [],
-            "config": {
-                "enabled": true
-            },
-            "unrendered_config": {},
-            "url": "http://localhost:3000/card/1",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "model.sandbox.customers"
-                ]
-            },
-            "refs": [
-                {
-                    "name": "customers",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "created_at": 1708330299.1877074
-        },
-        "exposure.sandbox.orders": {
-            "name": "orders",
-            "resource_type": "exposure",
-            "package_name": "sandbox",
-            "path": "exposures/our_analytics.yml",
-            "original_file_path": "models/exposures/our_analytics.yml",
-            "unique_id": "exposure.sandbox.orders",
-            "fqn": [
-                "sandbox",
-                "exposures",
-                "orders"
-            ],
-            "type": "analysis",
-            "owner": {
-                "email": "dbtmetabase@example.com",
-                "name": "dbtmetabase"
-            },
-            "description": "### Visualization: Table\n\nNo description provided in Metabase\n\n#### Metadata\n\nMetabase ID: __2__\n\nCreated On: __2024-02-19T03:48:08.251792__",
-            "label": "Orders",
-            "maturity": "medium",
-            "meta": {},
-            "tags": [],
-            "config": {
-                "enabled": true
-            },
-            "unrendered_config": {},
-            "url": "http://localhost:3000/card/2",
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "model.sandbox.orders"
-                ]
-            },
-            "refs": [
-                {
-                    "name": "orders",
-                    "package": null,
-                    "version": null
-                }
-            ],
-            "sources": [],
-            "metrics": [],
-            "created_at": 1708330299.1887019
-        }
-    },
+    "exposures": {},
     "metrics": {},
     "groups": {},
     "selectors": {},
@@ -12423,14 +12560,9 @@
             "model.sandbox.stg_orders",
             "model.sandbox.stg_payments"
         ],
-        "seed.sandbox.raw_customers": [],
-        "seed.sandbox.raw_orders": [],
-        "seed.sandbox.raw_payments": [],
-        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [
-            "model.sandbox.customers"
-        ],
-        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [
-            "model.sandbox.customers"
+        "model.sandbox.orders": [
+            "model.sandbox.stg_orders",
+            "model.sandbox.stg_payments"
         ],
         "model.sandbox.stg_customers": [
             "seed.sandbox.raw_customers"
@@ -12441,33 +12573,14 @@
         "model.sandbox.stg_orders": [
             "seed.sandbox.raw_orders"
         ],
-        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [
-            "model.sandbox.stg_customers"
+        "seed.sandbox.raw_customers": [],
+        "seed.sandbox.raw_orders": [],
+        "seed.sandbox.raw_payments": [],
+        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [
+            "model.sandbox.customers"
         ],
-        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [
-            "model.sandbox.stg_customers"
-        ],
-        "test.sandbox.unique_stg_payments_payment_id.3744510712": [
-            "model.sandbox.stg_payments"
-        ],
-        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [
-            "model.sandbox.stg_payments"
-        ],
-        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [
-            "model.sandbox.stg_payments"
-        ],
-        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [
-            "model.sandbox.stg_orders"
-        ],
-        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [
-            "model.sandbox.stg_orders"
-        ],
-        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [
-            "model.sandbox.stg_orders"
-        ],
-        "model.sandbox.orders": [
-            "model.sandbox.stg_orders",
-            "model.sandbox.stg_payments"
+        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [
+            "model.sandbox.customers"
         ],
         "test.sandbox.unique_orders_order_id.fed79b3a6e": [
             "model.sandbox.orders"
@@ -12496,34 +12609,47 @@
         "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": [
             "model.sandbox.orders"
         ],
-        "exposure.sandbox.clients": [
-            "model.sandbox.customers"
+        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [
+            "model.sandbox.stg_customers"
         ],
-        "exposure.sandbox.customers": [
-            "model.sandbox.customers"
+        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [
+            "model.sandbox.stg_customers"
         ],
-        "exposure.sandbox.orders": [
-            "model.sandbox.orders"
+        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [
+            "model.sandbox.stg_orders"
+        ],
+        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [
+            "model.sandbox.stg_orders"
+        ],
+        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [
+            "model.sandbox.stg_orders"
+        ],
+        "test.sandbox.unique_stg_payments_payment_id.3744510712": [
+            "model.sandbox.stg_payments"
+        ],
+        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [
+            "model.sandbox.stg_payments"
+        ],
+        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [
+            "model.sandbox.stg_payments"
         ]
     },
     "child_map": {
         "model.sandbox.customers": [
-            "exposure.sandbox.clients",
-            "exposure.sandbox.customers",
             "test.sandbox.not_null_customers_customer_id.5c9bf9911d",
             "test.sandbox.unique_customers_customer_id.c5af1ff4b1"
         ],
-        "seed.sandbox.raw_customers": [
-            "model.sandbox.stg_customers"
+        "model.sandbox.orders": [
+            "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+            "test.sandbox.not_null_orders_amount.106140f9fd",
+            "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49",
+            "test.sandbox.not_null_orders_coupon_amount.ab90c90625",
+            "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59",
+            "test.sandbox.not_null_orders_customer_id.c5f02694af",
+            "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a",
+            "test.sandbox.not_null_orders_order_id.cf6c17daed",
+            "test.sandbox.unique_orders_order_id.fed79b3a6e"
         ],
-        "seed.sandbox.raw_orders": [
-            "model.sandbox.stg_orders"
-        ],
-        "seed.sandbox.raw_payments": [
-            "model.sandbox.stg_payments"
-        ],
-        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [],
-        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [],
         "model.sandbox.stg_customers": [
             "model.sandbox.customers",
             "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa",
@@ -12543,26 +12669,17 @@
             "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64",
             "test.sandbox.unique_stg_orders_order_id.e3b841c71a"
         ],
-        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [],
-        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
-        "test.sandbox.unique_stg_payments_payment_id.3744510712": [],
-        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [],
-        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [],
-        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [],
-        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [],
-        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
-        "model.sandbox.orders": [
-            "exposure.sandbox.orders",
-            "test.sandbox.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
-            "test.sandbox.not_null_orders_amount.106140f9fd",
-            "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49",
-            "test.sandbox.not_null_orders_coupon_amount.ab90c90625",
-            "test.sandbox.not_null_orders_credit_card_amount.d3ca593b59",
-            "test.sandbox.not_null_orders_customer_id.c5f02694af",
-            "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a",
-            "test.sandbox.not_null_orders_order_id.cf6c17daed",
-            "test.sandbox.unique_orders_order_id.fed79b3a6e"
+        "seed.sandbox.raw_customers": [
+            "model.sandbox.stg_customers"
         ],
+        "seed.sandbox.raw_orders": [
+            "model.sandbox.stg_orders"
+        ],
+        "seed.sandbox.raw_payments": [
+            "model.sandbox.stg_payments"
+        ],
+        "test.sandbox.unique_customers_customer_id.c5af1ff4b1": [],
+        "test.sandbox.not_null_customers_customer_id.5c9bf9911d": [],
         "test.sandbox.unique_orders_order_id.fed79b3a6e": [],
         "test.sandbox.not_null_orders_order_id.cf6c17daed": [],
         "test.sandbox.not_null_orders_customer_id.c5f02694af": [],
@@ -12572,11 +12689,17 @@
         "test.sandbox.not_null_orders_coupon_amount.ab90c90625": [],
         "test.sandbox.not_null_orders_bank_transfer_amount.7743500c49": [],
         "test.sandbox.not_null_orders_gift_card_amount.413a0d2d7a": [],
-        "exposure.sandbox.clients": [],
-        "exposure.sandbox.customers": [],
-        "exposure.sandbox.orders": []
+        "test.sandbox.unique_stg_customers_customer_id.c7614daada": [],
+        "test.sandbox.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
+        "test.sandbox.unique_stg_orders_order_id.e3b841c71a": [],
+        "test.sandbox.not_null_stg_orders_order_id.81cfe2fe64": [],
+        "test.sandbox.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
+        "test.sandbox.unique_stg_payments_payment_id.3744510712": [],
+        "test.sandbox.not_null_stg_payments_payment_id.c19cc50075": [],
+        "test.sandbox.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": []
     },
     "group_map": {},
     "saved_queries": {},
-    "semantic_models": {}
+    "semantic_models": {},
+    "unit_tests": {}
 }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -19,8 +19,8 @@ class TestManifest(unittest.TestCase):
         self.assertIsNone(customer_id_col.fk_target_table)
         self.assertIsNone(customer_id_col.fk_target_field)
 
-    def test_v11(self):
-        models = Manifest(FIXTURES_PATH / "manifest-v11.json").read_models()
+    def test_v12(self):
+        models = Manifest(FIXTURES_PATH / "manifest-v12.json").read_models()
         self._assertModelsEqual(
             models,
             [


### PR DESCRIPTION
- Upgrade test dependencies to [dbt-postgres 1.8.1](https://github.com/dbt-labs/dbt-postgres/releases/tag/v1.8.1)
  - `tests` renamed `data_tests`
  - Save manifest [v12](https://schemas.getdbt.com/dbt/manifest/v12/index.html) as unit test fixture
- Add sandbox Docker dependencies to build `psycopg` from source
- Upgrade sandbox Metabase to 0.50.3
- Fix session ID warning in unit test Metabase mock