### PR TITLE
Rename Dockerfile.metabase and CURL_FLAGS

### DIFF
--- a/sandbox/Dockerfile.metabase
+++ b/sandbox/Dockerfile.metabase
@@ -1,8 +1,9 @@
 FROM eclipse-temurin:11-jre
 
 ARG MB_VERSION
+ARG CURL_FLAGS
 
-RUN curl -O https://downloads.metabase.com/v${MB_VERSION}/metabase.jar
+RUN curl -O ${CURL_FLAGS} https://downloads.metabase.com/v${MB_VERSION}/metabase.jar
 
 EXPOSE 3000
 

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -22,9 +22,10 @@ services:
   metabase:
     # image: metabase/metabase:latest
     build:
-      dockerfile: Dockerfile-metabase
+      dockerfile: Dockerfile.metabase
       args:
         - MB_VERSION=0.50.5
+        - CURL_FLAGS=${CURL_FLAGS:-}
     environment:
       - MB_SETUP_TOKEN=${MB_SETUP_TOKEN:-}
       - MB_DB_FILE=/metabase-data/metabase.db


### PR DESCRIPTION
- Rename Dockerfile-metabase to Dockerfile.metabase per convention
- Allow custom cURL flags to pass security/certificate configs