### PR TITLE
Skip tables that are technical not just hidden

### DIFF
--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -100,7 +100,7 @@ class ModelsMixin(metaclass=ABCMeta):
 
                     field = table.get("fields", {}).get(column_name)
                     if not field:
-                        if table.get("visibility_type") == "hidden":
+                        if table.get("visibility_type") is not None:
                             table_label = "hidden table"
                             table["stale"] = True
                         else:


### PR DESCRIPTION
Tables are hidden with any non-nil value - we hide our tables with  `technical` so would be useful to update this.