### PR TITLE
Allow backtick for table name

### DIFF
--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -25,7 +25,7 @@ from .manifest import Manifest
 _RESOURCE_VERSION = 2
 
 # Extracting table in `from` and `join` clauses (won't recognize some valid SQL, e.g. `from "table with spaces"`)
-_EXPOSURE_PARSER = re.compile(r"[FfJj][RrOo][OoIi][MmNn]\s+([\w.\"]+)")
+_EXPOSURE_PARSER = re.compile(r"[FfJj][RrOo][OoIi][MmNn]\s+([\w.\"`]+)")
 _CTE_PARSER = re.compile(
     r"[Ww][Ii][Tt][Hh]\s+\b(\w+)\b\s+as|[)]\s*[,]\s*\b(\w+)\b\s+as"
 )


### PR DESCRIPTION
Hello!

I am using BigQuery with Metabase and when using custom SQL I use backtick "`" for the table name like:
```sql
select *
  from `dataset.table_name`
```
And doing so the `depends_on` is empty:
```
    depends_on: []
```

Here is a full exemple of what I get:
```yaml
  - name: game_number_of_install
    label: Game number of install
    description: "### Visualization: Bar\n\nNo description provided in Metabase\n\n\
      #### Query\n\n```\nselect  game_title,\n        TIMESTAMP_TRUNC(mixpanel_ce_time,\
      \ MONTH) as Month,\n        count(1) as nb_install\n from `game_activity_marts.game_activity__marts__games_activity`\n\
      where mixpanel_ce_type = \"install_game\"\nAND company_secret = ( usersecret\
      \ )\n[[ AND ( date_Filter ) ]]\n[[ AND (Item_Name) ]]\ngroup by 1, 2\n```\n\n\
      #### Metadata\n\nMetabase ID: __2808__\n\nCreated On: __2024-09-11T15:35:26.612796Z__"
    type: analysis
    url: https://...
    maturity: medium
    owner:
      name: Olivier Norture
      email: ....
    depends_on: []
```

So I propose to add the backtick in the `_EXPOSURE_PARSER` regex.
Here is the [BigQuery documentation link](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#quoted_identifiers)

I didn't add test because I don't know how to update your metabase test (I only found a db file and nothing that create it); and I'm not sure that Postgres support backtick.