### PR TITLE
feat: query average time and last usage metadata

### DIFF
--- a/tests/fixtures/exposure/collection/our_analytics.yml
+++ b/tests/fixtures/exposure/collection/our_analytics.yml
@@ -46,6 +46,9 @@ exposures:
       name: dbtmetabase
       email: dbtmetabase@example.com
     depends_on: []
+    meta:
+      average_query_time: '0:00.028'
+      last_used_at: '2024-06-20T05:56:57.295379Z'
   - name: dummy_1
     label: Dummy
     description: '### Visualization: Table
@@ -78,6 +81,9 @@ exposures:
       name: dbtmetabase
       email: dbtmetabase@example.com
     depends_on: []
+    meta:
+      average_query_time: '0:00.024'
+      last_used_at: '2024-06-20T05:57:12.297288Z'
   - name: orders___customers
     label: Orders + Customers
     description: '### Visualization: Table
@@ -102,6 +108,9 @@ exposures:
     depends_on:
       - ref('customers')
       - ref('orders')
+    meta:
+      average_query_time: '0:00.107'
+      last_used_at: '2024-06-20T05:55:59.079272Z'
   - name: orders___customers__filtered_by_status_is_completed
     label: Orders + Customers, Filtered by Status is completed
     description: '### Visualization: Table
@@ -126,6 +135,9 @@ exposures:
     depends_on:
       - ref('customers')
       - ref('orders')
+    meta:
+      average_query_time: '0:00.264'
+      last_used_at: '2024-06-19T12:09:31.689381Z'
   - name: returned_order_count_sql
     label: Returned Order Count SQL
     description: "### Visualization: Scalar\n\nNo description provided in Metabase\n\
@@ -141,6 +153,9 @@ exposures:
     depends_on:
       - ref('stg_orders')
       - ref('stg_payments')
+    meta:
+      average_query_time: '0:00.191'
+      last_used_at: '2024-06-19T12:09:31.486489Z'
   - name: the_dashboard
     label: The Dashboard
     description: '### Dashboard Cards: 3
@@ -190,3 +205,6 @@ exposures:
       email: dbtmetabase@example.com
     depends_on:
       - ref('payments')
+    meta:
+      average_query_time: '0:00.058'
+      last_used_at: '2024-10-12T01:52:30.585371Z'

--- a/tests/fixtures/exposure/default/exposures.yml
+++ b/tests/fixtures/exposure/default/exposures.yml
@@ -48,6 +48,9 @@ exposures:
       name: dbtmetabase
       email: dbtmetabase@example.com
     depends_on: []
+    meta:
+      average_query_time: '0:00.028'
+      last_used_at: '2024-06-20T05:56:57.295379Z'
     tags:
       - metabase
   - name: dummy_1
@@ -82,6 +85,9 @@ exposures:
       name: dbtmetabase
       email: dbtmetabase@example.com
     depends_on: []
+    meta:
+      average_query_time: '0:00.024'
+      last_used_at: '2024-06-20T05:57:12.297288Z'
     tags:
       - metabase
   - name: orders___customers
@@ -108,6 +114,9 @@ exposures:
     depends_on:
       - ref('customers')
       - ref('orders')
+    meta:
+      average_query_time: '0:00.107'
+      last_used_at: '2024-06-20T05:55:59.079272Z'
     tags:
       - metabase
   - name: orders___customers__filtered_by_status_is_completed
@@ -134,6 +143,9 @@ exposures:
     depends_on:
       - ref('customers')
       - ref('orders')
+    meta:
+      average_query_time: '0:00.264'
+      last_used_at: '2024-06-19T12:09:31.689381Z'
     tags:
       - metabase
   - name: returned_order_count_sql
@@ -151,6 +163,9 @@ exposures:
     depends_on:
       - ref('stg_orders')
       - ref('stg_payments')
+    meta:
+      average_query_time: '0:00.191'
+      last_used_at: '2024-06-19T12:09:31.486489Z'
     tags:
       - metabase
   - name: the_dashboard
@@ -204,5 +219,8 @@ exposures:
       email: dbtmetabase@example.com
     depends_on:
       - ref('payments')
+    meta:
+      average_query_time: '0:00.058'
+      last_used_at: '2024-10-12T01:52:30.585371Z'
     tags:
       - metabase

--- a/tests/fixtures/exposure/type/card/27.yml
+++ b/tests/fixtures/exposure/type/card/27.yml
@@ -24,3 +24,6 @@ exposures:
     depends_on:
       - ref('customers')
       - ref('orders')
+    meta:
+      average_query_time: '0:00.107'
+      last_used_at: '2024-06-20T05:55:59.079272Z'

--- a/tests/fixtures/exposure/type/card/28.yml
+++ b/tests/fixtures/exposure/type/card/28.yml
@@ -24,3 +24,6 @@ exposures:
     depends_on:
       - ref('customers')
       - ref('orders')
+    meta:
+      average_query_time: '0:00.264'
+      last_used_at: '2024-06-19T12:09:31.689381Z'

--- a/tests/fixtures/exposure/type/card/29.yml
+++ b/tests/fixtures/exposure/type/card/29.yml
@@ -15,3 +15,6 @@ exposures:
     depends_on:
       - ref('stg_orders')
       - ref('stg_payments')
+    meta:
+      average_query_time: '0:00.191'
+      last_used_at: '2024-06-19T12:09:31.486489Z'

--- a/tests/fixtures/exposure/type/card/30.yml
+++ b/tests/fixtures/exposure/type/card/30.yml
@@ -32,3 +32,6 @@ exposures:
       name: dbtmetabase
       email: dbtmetabase@example.com
     depends_on: []
+    meta:
+      average_query_time: '0:00.028'
+      last_used_at: '2024-06-20T05:56:57.295379Z'

--- a/tests/fixtures/exposure/type/card/31.yml
+++ b/tests/fixtures/exposure/type/card/31.yml
@@ -32,3 +32,6 @@ exposures:
       name: dbtmetabase
       email: dbtmetabase@example.com
     depends_on: []
+    meta:
+      average_query_time: '0:00.024'
+      last_used_at: '2024-06-20T05:57:12.297288Z'

--- a/tests/fixtures/exposure/type/card/33.yml
+++ b/tests/fixtures/exposure/type/card/33.yml
@@ -1,0 +1,28 @@
+version: 2
+exposures:
+  - name: transactions
+    label: Transactions
+    description: '### Visualization: Table
+
+
+      No description provided in Metabase
+
+
+      #### Metadata
+
+
+      Metabase ID: __33__
+
+
+      Created On: __2024-10-11T23:46:29.272117Z__'
+    type: analysis
+    url: http://localhost:3000/card/33
+    maturity: medium
+    owner:
+      name: dbtmetabase
+      email: dbtmetabase@example.com
+    depends_on:
+      - ref('payments')
+    meta:
+      average_query_time: '0:00.058'
+      last_used_at: '2024-10-12T01:52:30.585371Z'


### PR DESCRIPTION
- Card `average_query_time` (in milliseconds) presented as `0:00.000` in exposure metadata
- Card `last_used_at` (ISO 8601 timestamp) presented as-is in exposure metadata
- Update exposure fixtures to reflect these
- Continues #281
- Resolves #280