### PR TITLE
only trigger release action on released event

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ on:
       - master
   release:
     types:
-      - created
+      - released
 
 jobs:
   build:


### PR DESCRIPTION
Instead of when any release is created, to allow for drafts that don't do anything yet