### PR TITLE
fix: BigQuery SQL backticks

### DIFF
--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -299,6 +299,8 @@ class ExposuresMixin(metaclass=ABCMeta):
 
             # Parse SQL for exposures through FROM or JOIN clauses
             for sql_ref in re.findall(_EXPOSURE_PARSER, native_query):
+                sql_ref = sql_ref.strip("`")  # BigQuery uses backticks `dataset.table`
+
                 # DATABASE.schema.table -> [database, schema, table]
                 parsed_model_path = [s.strip('"').lower() for s in sql_ref.split(".")]
 


### PR DESCRIPTION
- Strip backticks surrounding fully-qualified refs in BigQuery SQL before splitting (e.g. ``dataset.table``)
- Fixes #298