### PR TITLE
refactor: remove testable mangled names

### DIFF
--- a/dbtmetabase/__init__.py
+++ b/dbtmetabase/__init__.py
@@ -9,7 +9,7 @@ __all__ = [
 ]
 
 try:
-    from ._version import __version__ as version  # type: ignore
+    from ._version import __version__ as version
 
     __version__ = version
 except ModuleNotFoundError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 import pytest
 
+import dbtmetabase._models
 from tests._mocks import TMP_PATH, MockDbtMetabase, MockMetabase
 
 
 @pytest.fixture(name="core")
 def fixture_core() -> MockDbtMetabase:
     c = MockDbtMetabase()
-    c._ModelsMixin__SYNC_PERIOD = 1  # type: ignore
+    dbtmetabase._models._SYNC_PERIOD = 1
     return c
 
 

--- a/tests/test_exposures.py
+++ b/tests/test_exposures.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from dbtmetabase._exposures import _Context, _Exposure
 from tests._mocks import FIXTURES_PATH, TMP_PATH, MockDbtMetabase
 
 
@@ -96,7 +97,7 @@ def test_extract_exposures_native_depends(
     query: str,
     expected: set,
 ):
-    ctx = MockDbtMetabase._ExposuresMixin__Context(  # type: ignore
+    ctx = _Context(
         model_refs={
             "database.schema.table0": "model0",
             "database.public.table1": "model1",
@@ -104,12 +105,12 @@ def test_extract_exposures_native_depends(
         database_names={1: "database"},
         table_names={},
     )
-    exposure = MockDbtMetabase._ExposuresMixin__Exposure(  # type: ignore
+    exposure = _Exposure(
         model="card",
         uid="",
         label="",
     )
-    core._ExposuresMixin__exposure_card(  # type: ignore
+    core._exposure_card(
         ctx=ctx,
         exposure=exposure,
         card={

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -80,7 +80,7 @@ def test_build_lookups(core: MockDbtMetabase):
         "INVENTORY.SKUS": {"SKU_ID", "PRODUCT"},
     }
 
-    actual_tables = core._ModelsMixin__get_tables(database_id="2")  # type: ignore
+    actual_tables = core._get_metabase_tables(database_id="2")
 
     assert set(actual_tables.keys()) == set(expected.keys())
 


### PR DESCRIPTION
- only internal logic extracted to decrease cyclomatic complexity, not intended to be testable separately, should have mangled names (`__` prefixed), to prevent clashing names between mixins
- private but separately testable logic should be `_` prefixed and sanely named
- not prefixed public names should be maintained and refactors count as breaking changes