### PR TITLE
Support setting decimals on numeric columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ In addition to foreign keys, semantic types and visibility types, Metabase also 
         metabase.has_field_values: list
         metabase.coercion_strategy: keyword
         metabase.number_style: decimal
+        metabase.decimals: 3
 ```
 
 See [Metabase documentation](https://www.metabase.com/docs/latest/api) for details and accepted values.

--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -409,6 +409,8 @@ class ModelsMixin(metaclass=ABCMeta):
         settings = api_field.get("settings") or {}
         if settings.get("number_style") != column.number_style and column.number_style:
             settings["number_style"] = column.number_style
+        if settings.get("decimals") != column.decimals and column.decimals:
+            settings["decimals"] = column.decimals
 
         if settings:
             body_field["settings"] = settings

--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -35,6 +35,7 @@ _COLUMN_META_FIELDS = _COMMON_META_FIELDS + [
     "has_field_values",
     "coercion_strate`gy",
     "number_style",
+    "decimals",
 ]
 # Must be covered by Model attributes
 _MODEL_META_FIELDS = _COMMON_META_FIELDS + [
@@ -375,6 +376,7 @@ class Column:
     has_field_values: Optional[str] = None
     coercion_strategy: Optional[str] = None
     number_style: Optional[str] = None
+    decimals: Optional[int] = None
 
     fk_target_table: Optional[str] = None
     fk_target_field: Optional[str] = None


### PR DESCRIPTION
Does what it says on the tin... Now one may use `metabase.decimals: 3` on numeric columns.