### PR TITLE
Only update the settings attribute on fields if there are setting changes

### DIFF
--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -409,10 +409,9 @@ class ModelsMixin(metaclass=ABCMeta):
         settings = api_field.get("settings") or {}
         if settings.get("number_style") != column.number_style and column.number_style:
             settings["number_style"] = column.number_style
+            body_field["settings"] = settings
         if settings.get("decimals") != column.decimals and column.decimals:
             settings["decimals"] = column.decimals
-
-        if settings:
             body_field["settings"] = settings
 
         # Allow explicit null type to override detected one


### PR DESCRIPTION
The code already tried to do this, but it actually checked if there were any entries in the column settings attribute - including those received from the API itself.

closes #315