### PR TITLE
feat: support column currency

### DIFF
--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -411,6 +411,8 @@ class ModelsMixin(metaclass=ABCMeta):
             settings["number_style"] = column.number_style
         if settings.get("decimals") != column.decimals and column.decimals:
             settings["decimals"] = column.decimals
+        if settings.get("currency") != column.currency and column.currency:
+            settings["currency"] = column.currency
 
         if settings:
             body_field["settings"] = settings

--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -36,6 +36,7 @@ _COLUMN_META_FIELDS = _COMMON_META_FIELDS + [
     "coercion_strate`gy",
     "number_style",
     "decimals",
+    "currency",
 ]
 # Must be covered by Model attributes
 _MODEL_META_FIELDS = _COMMON_META_FIELDS + [
@@ -395,6 +396,7 @@ class Column:
     coercion_strategy: Optional[str] = None
     number_style: Optional[str] = None
     decimals: Optional[int] = None
+    currency: Optional[str] = None
 
     fk_target_table: Optional[str] = None
     fk_target_field: Optional[str] = None


### PR DESCRIPTION
- Support `metabase.settings.currency` applicable to `type/Currency` semantic type
- Resolves #317

```yaml
      - name: gross_purchase_amount_processed
        meta:
          metabase.semantic_type: type/Currency
          metabase.settings:
            currency: USD
```