### PR TITLE
feat: support BigQuery `project-id-from-credentials` for model FQN

### DIFF
--- a/dbtmetabase/_exposures.py
+++ b/dbtmetabase/_exposures.py
@@ -83,7 +83,13 @@ class ExposuresMixin(metaclass=ABCMeta):
 
         def dbname(details: Mapping) -> str:
             """Parse database name from Metabase database details."""
-            for key in ("dbname", "db", "project-id", "catalog"):
+            for key in (
+                "dbname",
+                "db",
+                "project-id",
+                "project-id-from-credentials",
+                "catalog",
+            ):
                 if key in details:
                     return details[key]
             return ""


### PR DESCRIPTION
- When BigQuery project ID is inferred from JSON service key, it appears as `project-id-from-credentials`
- Resolves #322