### PR TITLE
Support exposure extraction for MBQL 5 cards

### DIFF
--- a/tests/fixtures/api/card/34.json
+++ b/tests/fixtures/api/card/34.json
@@ -1,0 +1,89 @@
+{
+  "cache_invalidated_at": null,
+  "description": "MBQL 5 basic query",
+  "archived": false,
+  "view_count": 10,
+  "collection_position": null,
+  "table_id": 10,
+  "can_run_adhoc_query": true,
+  "result_metadata": [],
+  "creator": {
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_login": "2024-12-20T12:30:47.814008Z",
+    "is_qbnewb": false,
+    "is_superuser": true,
+    "id": 1,
+    "last_name": null,
+    "date_joined": "2024-06-19T11:49:37.507897Z",
+    "common_name": "dbtmetabase"
+  },
+  "initially_published_at": null,
+  "can_write": true,
+  "database_id": 2,
+  "enable_embedding": false,
+  "collection_id": null,
+  "query_type": "query",
+  "name": "Orders Count by Month (MBQL 5)",
+  "last_query_start": "2024-12-20T12:30:05.862314Z",
+  "dashboard_count": 0,
+  "last_used_at": "2024-12-20T12:30:05.932096Z",
+  "type": "question",
+  "average_query_time": 100.0,
+  "creator_id": 1,
+  "moderation_reviews": [],
+  "updated_at": "2024-12-20T12:30:11.735631Z",
+  "made_public_by_id": null,
+  "embedding_params": null,
+  "cache_ttl": null,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 10,
+        "aggregation": [
+          ["count", { "lib/uuid": "f3299ded-561b-4764-9ebb-b1868ab13932" }]
+        ],
+        "breakout": [
+          [
+            "field",
+            {
+              "temporal-unit": "month",
+              "lib/uuid": "90f0eac8-310b-4a5c-9e76-fff908b68765"
+            },
+            82
+          ]
+        ]
+      }
+    ],
+    "database": 2,
+    "lib.convert/converted?": true
+  },
+  "id": 34,
+  "parameter_mappings": [],
+  "display": "bar",
+  "entity_id": "Mbql5Basic123456789abc",
+  "collection_preview": true,
+  "last-edit-info": {
+    "id": 1,
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_name": null,
+    "timestamp": "2024-12-20T12:30:11.782155Z"
+  },
+  "visualization_settings": {},
+  "collection": {
+    "metabase.models.collection.root/is-root?": true,
+    "authority_level": null,
+    "name": "Our analytics",
+    "is_personal": false,
+    "id": "root",
+    "can_write": true
+  },
+  "metabase_version": "v0.50.5 (48f6978)",
+  "parameters": [],
+  "created_at": "2024-12-20T12:30:05.862314Z",
+  "parameter_usage_count": 0,
+  "public_uuid": null
+}

--- a/tests/fixtures/api/card/35.json
+++ b/tests/fixtures/api/card/35.json
@@ -1,0 +1,128 @@
+{
+  "cache_invalidated_at": null,
+  "description": "MBQL 5 query with joins",
+  "archived": false,
+  "view_count": 10,
+  "collection_position": null,
+  "table_id": 10,
+  "can_run_adhoc_query": true,
+  "result_metadata": [],
+  "creator": {
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_login": "2024-12-20T12:30:47.814008Z",
+    "is_qbnewb": false,
+    "is_superuser": true,
+    "id": 1,
+    "last_name": null,
+    "date_joined": "2024-06-19T11:49:37.507897Z",
+    "common_name": "dbtmetabase"
+  },
+  "initially_published_at": null,
+  "can_write": true,
+  "database_id": 2,
+  "enable_embedding": false,
+  "collection_id": null,
+  "query_type": "query",
+  "name": "Orders + Customers (MBQL 5)",
+  "last_query_start": "2024-12-20T12:30:05.862314Z",
+  "dashboard_count": 0,
+  "last_used_at": "2024-12-20T12:30:05.932096Z",
+  "type": "question",
+  "average_query_time": 100.0,
+  "creator_id": 1,
+  "moderation_reviews": [],
+  "updated_at": "2024-12-20T12:30:11.735631Z",
+  "made_public_by_id": null,
+  "embedding_params": null,
+  "cache_ttl": null,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 10,
+        "fields": [
+          [
+            "field",
+            {
+              "base-type": "type/Integer",
+              "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000001"
+            },
+            84
+          ],
+          [
+            "field",
+            {
+              "base-type": "type/Integer",
+              "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000002"
+            },
+            79
+          ]
+        ],
+        "joins": [
+          {
+            "alias": "Customers",
+            "fields": "all",
+            "conditions": [
+              [
+                "=",
+                { "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000003" },
+                [
+                  "field",
+                  {
+                    "base-type": "type/Integer",
+                    "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000004"
+                  },
+                  79
+                ],
+                [
+                  "field",
+                  {
+                    "base-type": "type/Integer",
+                    "join-alias": "Customers",
+                    "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000005"
+                  },
+                  94
+                ]
+              ]
+            ],
+            "lib/type": "mbql/join",
+            "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 12 }],
+            "lib/options": {
+              "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000006"
+            }
+          }
+        ]
+      }
+    ],
+    "database": 2,
+    "lib.convert/converted?": true
+  },
+  "id": 35,
+  "parameter_mappings": [],
+  "display": "table",
+  "entity_id": "Mbql5Join1234567890abc",
+  "collection_preview": true,
+  "last-edit-info": {
+    "id": 1,
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_name": null,
+    "timestamp": "2024-12-20T12:30:11.782155Z"
+  },
+  "visualization_settings": {},
+  "collection": {
+    "metabase.models.collection.root/is-root?": true,
+    "authority_level": null,
+    "name": "Our analytics",
+    "is_personal": false,
+    "id": "root",
+    "can_write": true
+  },
+  "metabase_version": "v0.50.5 (48f6978)",
+  "parameters": [],
+  "created_at": "2024-12-20T12:30:05.862314Z",
+  "parameter_usage_count": 0,
+  "public_uuid": null
+}

--- a/tests/fixtures/api/card/36.json
+++ b/tests/fixtures/api/card/36.json
@@ -1,0 +1,76 @@
+{
+  "cache_invalidated_at": null,
+  "description": "MBQL 5 native SQL query",
+  "archived": false,
+  "view_count": 10,
+  "collection_position": null,
+  "table_id": null,
+  "can_run_adhoc_query": true,
+  "result_metadata": [],
+  "creator": {
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_login": "2024-12-20T12:30:47.814008Z",
+    "is_qbnewb": false,
+    "is_superuser": true,
+    "id": 1,
+    "last_name": null,
+    "date_joined": "2024-06-19T11:49:37.507897Z",
+    "common_name": "dbtmetabase"
+  },
+  "initially_published_at": null,
+  "can_write": true,
+  "database_id": 2,
+  "enable_embedding": false,
+  "collection_id": null,
+  "query_type": "native",
+  "name": "Orders SQL (MBQL 5)",
+  "last_query_start": "2024-12-20T12:30:05.862314Z",
+  "dashboard_count": 0,
+  "last_used_at": "2024-12-20T12:30:05.932096Z",
+  "type": "question",
+  "average_query_time": 100.0,
+  "creator_id": 1,
+  "moderation_reviews": [],
+  "updated_at": "2024-12-20T12:30:11.735631Z",
+  "made_public_by_id": null,
+  "embedding_params": null,
+  "cache_ttl": null,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "stages": [
+      {
+        "lib/type": "mbql.stage/native",
+        "native": "SELECT * FROM public.orders WHERE status = 'completed'"
+      }
+    ],
+    "database": 2,
+    "lib.convert/converted?": true
+  },
+  "id": 36,
+  "parameter_mappings": [],
+  "display": "table",
+  "entity_id": "Mbql5Native12345678abc",
+  "collection_preview": true,
+  "last-edit-info": {
+    "id": 1,
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_name": null,
+    "timestamp": "2024-12-20T12:30:11.782155Z"
+  },
+  "visualization_settings": {},
+  "collection": {
+    "metabase.models.collection.root/is-root?": true,
+    "authority_level": null,
+    "name": "Our analytics",
+    "is_personal": false,
+    "id": "root",
+    "can_write": true
+  },
+  "metabase_version": "v0.50.5 (48f6978)",
+  "parameters": [],
+  "created_at": "2024-12-20T12:30:05.862314Z",
+  "parameter_usage_count": 0,
+  "public_uuid": null
+}

--- a/tests/fixtures/api/card/37.json
+++ b/tests/fixtures/api/card/37.json
@@ -1,0 +1,100 @@
+{
+  "cache_invalidated_at": null,
+  "description": "MBQL 5 multi-stage query",
+  "archived": false,
+  "view_count": 10,
+  "collection_position": null,
+  "table_id": 10,
+  "can_run_adhoc_query": true,
+  "result_metadata": [],
+  "creator": {
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_login": "2024-12-20T12:30:47.814008Z",
+    "is_qbnewb": false,
+    "is_superuser": true,
+    "id": 1,
+    "last_name": null,
+    "date_joined": "2024-06-19T11:49:37.507897Z",
+    "common_name": "dbtmetabase"
+  },
+  "initially_published_at": null,
+  "can_write": true,
+  "database_id": 2,
+  "enable_embedding": false,
+  "collection_id": null,
+  "query_type": "query",
+  "name": "High Volume Orders (MBQL 5 Multi-Stage)",
+  "last_query_start": "2024-12-20T12:30:05.862314Z",
+  "dashboard_count": 0,
+  "last_used_at": "2024-12-20T12:30:05.932096Z",
+  "type": "question",
+  "average_query_time": 100.0,
+  "creator_id": 1,
+  "moderation_reviews": [],
+  "updated_at": "2024-12-20T12:30:11.735631Z",
+  "made_public_by_id": null,
+  "embedding_params": null,
+  "cache_ttl": null,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 10,
+        "aggregation": [
+          ["count", { "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000010" }]
+        ],
+        "breakout": [
+          ["field", { "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000011" }, 79]
+        ]
+      },
+      {
+        "lib/type": "mbql.stage/mbql",
+        "filters": [
+          [
+            ">=",
+            { "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000012" },
+            [
+              "field",
+              {
+                "base-type": "type/Integer",
+                "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000013"
+              },
+              "count"
+            ],
+            10
+          ]
+        ]
+      }
+    ],
+    "database": 2,
+    "lib.convert/converted?": true
+  },
+  "id": 37,
+  "parameter_mappings": [],
+  "display": "table",
+  "entity_id": "Mbql5Multi1234567890ab",
+  "collection_preview": true,
+  "last-edit-info": {
+    "id": 1,
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_name": null,
+    "timestamp": "2024-12-20T12:30:11.782155Z"
+  },
+  "visualization_settings": {},
+  "collection": {
+    "metabase.models.collection.root/is-root?": true,
+    "authority_level": null,
+    "name": "Our analytics",
+    "is_personal": false,
+    "id": "root",
+    "can_write": true
+  },
+  "metabase_version": "v0.50.5 (48f6978)",
+  "parameters": [],
+  "created_at": "2024-12-20T12:30:05.862314Z",
+  "parameter_usage_count": 0,
+  "public_uuid": null
+}

--- a/tests/fixtures/api/card/38.json
+++ b/tests/fixtures/api/card/38.json
@@ -1,0 +1,91 @@
+{
+  "cache_invalidated_at": null,
+  "description": "MBQL 5 query based on another card",
+  "archived": false,
+  "view_count": 10,
+  "collection_position": null,
+  "table_id": null,
+  "can_run_adhoc_query": true,
+  "result_metadata": [],
+  "creator": {
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_login": "2024-12-20T12:30:47.814008Z",
+    "is_qbnewb": false,
+    "is_superuser": true,
+    "id": 1,
+    "last_name": null,
+    "date_joined": "2024-06-19T11:49:37.507897Z",
+    "common_name": "dbtmetabase"
+  },
+  "initially_published_at": null,
+  "can_write": true,
+  "database_id": 2,
+  "enable_embedding": false,
+  "collection_id": null,
+  "query_type": "query",
+  "name": "Orders Filtered (MBQL 5 source-card)",
+  "last_query_start": "2024-12-20T12:30:05.862314Z",
+  "dashboard_count": 0,
+  "last_used_at": "2024-12-20T12:30:05.932096Z",
+  "type": "question",
+  "average_query_time": 100.0,
+  "creator_id": 1,
+  "moderation_reviews": [],
+  "updated_at": "2024-12-20T12:30:11.735631Z",
+  "made_public_by_id": null,
+  "embedding_params": null,
+  "cache_ttl": null,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-card": 34,
+        "filters": [
+          [
+            ">=",
+            { "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000020" },
+            [
+              "field",
+              {
+                "base-type": "type/Integer",
+                "lib/uuid": "a1b2c3d4-0000-0000-0000-000000000021"
+              },
+              "count"
+            ],
+            5
+          ]
+        ]
+      }
+    ],
+    "database": 2,
+    "lib.convert/converted?": true
+  },
+  "id": 38,
+  "parameter_mappings": [],
+  "display": "table",
+  "entity_id": "Mbql5Card12345678901ab",
+  "collection_preview": true,
+  "last-edit-info": {
+    "id": 1,
+    "email": "dbtmetabase@example.com",
+    "first_name": "dbtmetabase",
+    "last_name": null,
+    "timestamp": "2024-12-20T12:30:11.782155Z"
+  },
+  "visualization_settings": {},
+  "collection": {
+    "metabase.models.collection.root/is-root?": true,
+    "authority_level": null,
+    "name": "Our analytics",
+    "is_personal": false,
+    "id": "root",
+    "can_write": true
+  },
+  "metabase_version": "v0.50.5 (48f6978)",
+  "parameters": [],
+  "created_at": "2024-12-20T12:30:05.862314Z",
+  "parameter_usage_count": 0,
+  "public_uuid": null
+}

--- a/tests/test_exposures.py
+++ b/tests/test_exposures.py
@@ -123,3 +123,116 @@ def test_extract_exposures_native_depends(
     )
     assert expected == exposure.depends
     assert query == exposure.native_query
+
+
+def test_mbql5_query_basic(core: MockDbtMetabase):
+    """Test MBQL 5 query with a simple source-table (34)."""
+
+    ctx = _Context(
+        model_refs={
+            "database.public.orders": "ref('orders')",
+        },
+        database_names={2: "database"},
+        table_names={10: "database.public.orders"},
+    )
+    exposure = _Exposure(
+        model="card",
+        uid="34",
+        label="Orders Count by Month (MBQL 5)",
+    )
+    card = core.metabase.find_card("34")
+    assert card is not None
+    core._exposure_card(ctx=ctx, exposure=exposure, card=card)
+    assert {"database.public.orders"} == exposure.depends
+
+
+def test_mbql5_query_with_source_card(core: MockDbtMetabase):
+    """Test MBQL 5 query that references another card via source-card (38 -> 34)."""
+
+    ctx = _Context(
+        model_refs={
+            "database.public.orders": "ref('orders')",
+        },
+        database_names={2: "database"},
+        table_names={10: "database.public.orders"},
+    )
+    exposure = _Exposure(
+        model="card",
+        uid="38",
+        label="Orders Filtered (MBQL 5 source-card)",
+    )
+    # Card 38 references card 34 via source-card, which references table 10
+    card = core.metabase.find_card("38")
+    assert card is not None
+    core._exposure_card(ctx=ctx, exposure=exposure, card=card)
+    assert {"database.public.orders"} == exposure.depends
+
+
+def test_mbql5_query_with_joins(core: MockDbtMetabase):
+    """Test MBQL 5 query with joins (35)."""
+
+    ctx = _Context(
+        model_refs={
+            "database.public.orders": "ref('orders')",
+            "database.public.customers": "ref('customers')",
+        },
+        database_names={2: "database"},
+        table_names={
+            10: "database.public.orders",
+            12: "database.public.customers",
+        },
+    )
+    exposure = _Exposure(
+        model="card",
+        uid="35",
+        label="Orders + Customers (MBQL 5)",
+    )
+    card = core.metabase.find_card("35")
+    assert card is not None
+    core._exposure_card(ctx=ctx, exposure=exposure, card=card)
+    assert {"database.public.orders", "database.public.customers"} == exposure.depends
+
+
+def test_mbql5_native_query(core: MockDbtMetabase):
+    """Test MBQL 5 native (SQL) query stage (36)."""
+
+    ctx = _Context(
+        model_refs={
+            "database.public.orders": "ref('orders')",
+        },
+        database_names={2: "database"},
+        table_names={},
+    )
+    exposure = _Exposure(
+        model="card",
+        uid="36",
+        label="Orders SQL (MBQL 5)",
+    )
+    card = core.metabase.find_card("36")
+    assert card is not None
+    core._exposure_card(ctx=ctx, exposure=exposure, card=card)
+    assert {"database.public.orders"} == exposure.depends
+    assert (
+        "SELECT * FROM public.orders WHERE status = 'completed'"
+        == exposure.native_query
+    )
+
+
+def test_mbql5_multi_stage_query(core: MockDbtMetabase):
+    """Test MBQL 5 query with multiple stages (card 37)."""
+    ctx = _Context(
+        model_refs={
+            "database.public.orders": "ref('orders')",
+        },
+        database_names={2: "database"},
+        table_names={10: "database.public.orders"},
+    )
+    exposure = _Exposure(
+        model="card",
+        uid="37",
+        label="High Volume Orders (MBQL 5 Multi-Stage)",
+    )
+    card = core.metabase.find_card("37")
+    assert card is not None
+    core._exposure_card(ctx=ctx, exposure=exposure, card=card)
+    assert {"database.public.orders"} == exposure.depends


### PR DESCRIPTION
As of Metabase 0.57, cards are serialized in MBQL 5 format:

> MBQL queries (in Cards and elsewhere) are now serialized as MBQL 5 as opposed to MBQL 4 (aka legacy MBQL) in the application database and in REST API responses. While we do not officially support editing or introspection of MBQL via the REST API (please treat it as an opaque object), to support existing usages the GET /api/card/:id endpoint can return the Card dataset_query as MBQL 4 if you include the query parameter ?legacy-mbql=true.
-- https://www.metabase.com/docs/latest/developers-guide/api-changelog#metabase-0570

This PR updates card parsing to support the new format.

Now, It wasn't until I was submitting this PR that I noticed that last part about being able to request legacy mbql with `?legacy-mbql=true`. To support Metabase 0.57+, you either need the changes in this PR or to switch to using that query param when fetching cards with the existing legacy implementation.
