### PR TITLE
Trigger release action on published

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - main
   release:
     types:
-      - released
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
- Event `released` only applies to final releases, `published` works for pre-releases too
- https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release