### PR TITLE
Fix for #360: Handle 403 errors for card and user access

### DIFF
--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -199,7 +199,7 @@ class Metabase:
                 _logger.warning("User '%s' not found", uid)
                 return None
             elif error.response.status_code == 403:
-                _logger.warning("No permission to fetch user '%s', skipping creator info", uid)
+                _logger.warning("User '%s' not accessible", uid)
                 return None
             elif (
                 error.response.status_code == 400

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -167,6 +167,9 @@ class Metabase:
             if error.response.status_code == 404:
                 _logger.warning("Card '%s' not found", uid)
                 return None
+            elif error.response.status_code == 403:
+                _logger.warning("Card '%s' not accessible", uid)
+                return None
             raise
 
     def format_card_url(self, uid: str) -> str:
@@ -194,6 +197,9 @@ class Metabase:
         except requests.exceptions.HTTPError as error:
             if error.response.status_code == 404:
                 _logger.warning("User '%s' not found", uid)
+                return None
+            elif error.response.status_code == 403:
+                _logger.warning("No permission to fetch user '%s', skipping creator info", uid)
                 return None
             elif (
                 error.response.status_code == 400


### PR DESCRIPTION
- Handle 403 responses in `find_card` and `find_user` to prevent exposure generation from failing when cards are in personal collections.
- Resolves #360