### PR TITLE
Fix MySQL/MariaDB schema fallback in _build_tables

### DIFF
--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -481,11 +481,11 @@ def _build_tables(metadata: Mapping) -> Mapping[str, MutableMapping]:
     engine = metadata.get("engine", "")
     if "bigquery" in engine:
         default_schema = metadata.get("details", {}).get("dataset-id")
-    elif "athena" in engine:
+    elif "athena" in engine or "mysql" in engine or "mariadb" in engine:
         default_schema = metadata.get("details", {}).get("dbname")
 
     for table in metadata.get("tables", []):
-        # table[schema] is null for bigquery datasets
+        # table[schema] is null for bigquery datasets and empty for mysql/mariadb
         table["schema"] = (table.get("schema") or default_schema).upper()
 
         fields = {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@ from collections.abc import MutableSequence
 from typing import cast
 from unittest.mock import Mock
 
+import pytest
+
 from dbtmetabase._models import _build_tables, _Context
 from dbtmetabase.manifest import Column, Group, Model
 from tests._mocks import MockDbtMetabase
@@ -236,6 +238,29 @@ def test_multi_database_model_matching():
         else:
             # Single-database
             assert table_key == f"{schema_name}.{model_name}"
+
+
+@pytest.mark.parametrize("engine", ["mysql", "mariadb"])
+def test_mysql_like_default_schema_fallback(engine: str):
+    """MySQL/MariaDB JDBC reports schema as empty; fall back to details.dbname."""
+
+    metadata = {
+        "engine": engine,
+        "details": {"dbname": "my_db"},
+        "tables": [
+            {
+                "id": 1,
+                "name": "my_model",
+                "schema": "",
+                "fields": [{"id": 1, "name": "id"}],
+            },
+        ],
+    }
+
+    tables = _build_tables(metadata=metadata)
+
+    assert "MY_DB.MY_MODEL" in tables
+    assert tables["MY_DB.MY_MODEL"]["schema"] == "MY_DB"
 
 
 def test_multi_database_foreign_key_resolution():


### PR DESCRIPTION
## Problem

Metabase's MySQL/MariaDB driver reports each table's `schema` as an empty string (the JDBC concept of "schema" doesn't map cleanly onto MySQL's flat database model). As a result, `_build_tables` builds keys like `.my_model` instead of `my_db.my_model`, no dbt model ever matches, and `export_models` silently no-ops on a MySQL warehouse.

## Fix

Extend the existing Athena fallback to also cover `mysql` and `mariadb`: when the engine is one of those, use `details.dbname` as the default schema. One-line change in `_build_tables`, parametrized unit test covering both engines.

I know MySQL / MariaDB are uncommon warehouse choices, but I believe the change is light enough to carry support for them. 