### PR TITLE
Fix cross-schema foreign key constraints resolving to the wrong schema

### DIFF
--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -70,6 +70,15 @@ class Manifest:
         with open(self.path, encoding="utf-8") as f:
             manifest = json.load(f)
 
+        # Schema of every model, keyed by name, so that foreign keys pointing at a
+        # bare model name (e.g. from `ref('model')`) can be resolved to the schema of
+        # the target model rather than assuming the referencing model's schema.
+        ref_schemas = {
+            node["name"]: node["schema"]
+            for node in manifest["nodes"].values()
+            if node["resource_type"] == "model"
+        }
+
         models: MutableSequence[Model] = []
 
         for node in manifest["nodes"].values():
@@ -81,14 +90,20 @@ class Manifest:
                 _logger.debug("Skipping ephemeral model '%s'", name)
                 continue
 
-            models.append(self._read_model(manifest, node, Group.nodes))
+            models.append(self._read_model(manifest, node, Group.nodes, ref_schemas))
 
         for node in manifest["sources"].values():
             if node["resource_type"] != "source":
                 continue
 
             models.append(
-                self._read_model(manifest, node, Group.sources, node["source_name"])
+                self._read_model(
+                    manifest,
+                    node,
+                    Group.sources,
+                    ref_schemas,
+                    node["source_name"],
+                )
             )
 
         return models
@@ -98,6 +113,7 @@ class Manifest:
         manifest: Mapping,
         manifest_model: Mapping,
         group: Group,
+        ref_schemas: Mapping[str, str] | None = None,
         source: str | None = None,
     ) -> Model:
         database = manifest_model["database"]
@@ -107,7 +123,9 @@ class Manifest:
         relationships = self._read_relationships(manifest, group, unique_id)
 
         columns = [
-            self._read_column(column, schema, relationships.get(column["name"]))
+            self._read_column(
+                column, schema, relationships.get(column["name"]), ref_schemas
+            )
             for column in manifest_model.get("columns", {}).values()
         ]
 
@@ -139,6 +157,7 @@ class Manifest:
         manifest_column: Mapping,
         schema: str,
         relationship: Mapping | None,
+        ref_schemas: Mapping[str, str] | None = None,
     ) -> Column:
         meta = self._scan_fields(
             manifest_column.get("meta", {}),
@@ -158,6 +177,7 @@ class Manifest:
             column=column,
             schema=schema,
             relationship=relationship,
+            ref_schemas=ref_schemas,
         )
 
         return column
@@ -269,6 +289,7 @@ class Manifest:
         column: Column,
         schema: str,
         relationship: Mapping | None,
+        ref_schemas: Mapping[str, str] | None = None,
     ):
         """Sets primary key and foreign key target on a column from constraints, meta fields or provided test relationship."""
 
@@ -334,8 +355,13 @@ class Manifest:
             return
 
         fk_target_table_path = fk_target_table.split(".")
-        if len(fk_target_table_path) == 1 and schema:
-            fk_target_table_path.insert(0, schema)
+        if len(fk_target_table_path) == 1 and fk_target_table_path[0]:
+            # A bare, single-segment target (e.g. from `ref('model')` or `model (column)`)
+            # carries no schema. Resolve it to the target model's actual schema, falling
+            # back to the referencing model's schema only when the target is unknown.
+            target_schema = (ref_schemas or {}).get(fk_target_table_path[0], schema)
+            if target_schema:
+                fk_target_table_path.insert(0, target_schema)
 
         column.semantic_type = "type/FK"
         column.fk_target_table = ".".join([x.strip('"`') for x in fk_target_table_path])

--- a/tests/fixtures/manifest-cross-schema-fk.json
+++ b/tests/fixtures/manifest-cross-schema-fk.json
@@ -1,0 +1,83 @@
+{
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+        "project_name": "sandbox"
+    },
+    "nodes": {
+        "model.sandbox.stg_customers": {
+            "database": "dbtmetabase",
+            "schema": "staging",
+            "name": "stg_customers",
+            "resource_type": "model",
+            "unique_id": "model.sandbox.stg_customers",
+            "alias": "stg_customers",
+            "config": {
+                "materialized": "view"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "",
+                    "meta": {},
+                    "constraints": [
+                        {
+                            "type": "primary_key"
+                        }
+                    ]
+                }
+            },
+            "meta": {}
+        },
+        "model.sandbox.orders": {
+            "database": "dbtmetabase",
+            "schema": "public",
+            "name": "orders",
+            "resource_type": "model",
+            "unique_id": "model.sandbox.orders",
+            "alias": "orders",
+            "config": {
+                "materialized": "table"
+            },
+            "tags": [],
+            "description": "This table has basic information about orders",
+            "columns": {
+                "order_id": {
+                    "name": "order_id",
+                    "description": "This is a unique identifier for an order",
+                    "meta": {},
+                    "constraints": [
+                        {
+                            "type": "primary_key"
+                        }
+                    ]
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "Foreign key to the stg_customers table in another schema",
+                    "meta": {},
+                    "constraints": [
+                        {
+                            "type": "foreign_key",
+                            "name": null,
+                            "expression": null,
+                            "warn_unenforced": true,
+                            "warn_unsupported": true,
+                            "to": "ref('stg_customers')",
+                            "to_columns": [
+                                "customer_id"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "meta": {}
+        }
+    },
+    "sources": {},
+    "child_map": {
+        "model.sandbox.stg_customers": [],
+        "model.sandbox.orders": []
+    }
+}

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -20,6 +20,20 @@ def test_v11_disabled():
     assert customer_id_col.fk_target_field is None
 
 
+def test_cross_schema_foreign_key_constraint():
+    manifest = MockManifest(FIXTURES_PATH / "manifest-cross-schema-fk.json")
+    manifest.read_models()
+
+    # `orders` lives in `public` but its foreign key targets `stg_customers`, which
+    # lives in `staging`. The FK target must use the target model's schema, not the
+    # referencing model's schema.
+    customer_id_col = manifest.find_column("orders", "customer_id")
+    assert customer_id_col is not None
+    assert customer_id_col.semantic_type == "type/FK"
+    assert customer_id_col.fk_target_table == "staging.stg_customers"
+    assert customer_id_col.fk_target_field == "customer_id"
+
+
 def test_v12():
     models = Manifest(FIXTURES_PATH / "manifest-v12.json").read_models()
     _assert_models_equal(


### PR DESCRIPTION
Fixes #391.

## Problem

A `foreign_key` constraint whose target is a bare model name — `to: ref('model')` or `expression: model (column)` — was resolved to the **referencing** model's schema instead of the target model's schema. For a cross-schema FK this points the relationship at a non-existent `<referencing_schema>.<target>` table, which surfaces during sync as `... referenced as foreign key ... not found` and aborts with `MetabaseStateError`.

The offending fallback in `_set_column_relationship`:

```python
fk_target_table_path = fk_target_table.split(".")
if len(fk_target_table_path) == 1 and schema:
    fk_target_table_path.insert(0, schema)   # schema = the *referencing* model's schema
```

Relationship-test FKs already resolve the correct schema (from the target node), so only the constraints path was affected.

## When does this trigger?

Only when the manifest stores the FK target as the literal `ref('model')` (single-segment), rather than a resolved relation:

- **Classic dbt-core** rewrites `constraint.to` to a fully-qualified relation during `dbt compile`, so its manifests take the existing `len(path) <= 3` branch and were already correct. I verified this with dbt-core 1.11.7 + duckdb: a cross-schema FK compiled to `to = '"verify"."main_staging"."stg_customers"'`, and unpatched dbt-metabase resolved it correctly (`main_staging.stg_customers`). This is why it hasn't surfaced for most users, and matches the resolved 3-part `to` seen in #310.
- **The literal form** appears with dbt's newer date-versioned engine (`dbt_version: 2026.7.x`), which leaves `constraint.to` as `ref('model')` even after `dbt compile`, and with a plain `dbt parse`. That single-segment target is what hit the bug.

The literal `ref('model')` is valid manifest content that dbt-metabase already parses (`_REF_PARSER`), so this fixes existing, intended handling rather than adding new support.

## Fix

- Build a `name -> schema` map from the manifest models once in `read_models`, and thread it down to `_set_column_relationship`.
- When a FK target is a bare, single-segment name, qualify it with the **target** model's schema from that map, falling back to the referencing model's schema only when the target is unknown (preserving prior behavior for that case).

Already schema-qualified targets (`schema.model`, `db.schema.model`) and relationship-test FKs are unchanged. The new parameter is optional and defaults to `None`, so the existing direct-call unit test (`test_set_column_relationship_parses_constraint_to_formats`) is unaffected.

## Test

Adds `test_cross_schema_foreign_key_constraint`, a fixture-based regression test (`tests/fixtures/manifest-cross-schema-fk.json`) with a mart `orders` (schema `public`) whose FK targets `stg_customers` (schema `staging`). It asserts `fk_target_table == "staging.stg_customers"`.

Verified it fails on `main` (`public.stg_customers`) and passes with this change. Full suite (`make test` → 50 passed), `ruff format`/`ruff check`, and `pyright` are all green.
