### PR TITLE
Remap foreign key display values to a target's declared display field

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ Native [relationship tests](https://docs.getdbt.com/reference/resource-propertie
 
 You can provide `fk_target_table` as `schema_name.table_name` or just `table_name` to use the current schema. If your model has an alias, provide that alias rather than the original name.
 
+### Display Values
+
+By default a foreign key column shows the raw id it points at. Metabase can instead display a human-readable column from the target table (its "display value"). Mark that column once, on the target model, with `metabase.display_field`:
+
+```yaml
+- name: campaign_name
+  config:
+    meta:
+      metabase.display_field: true
+```
+
+Every foreign key that resolves to this table — however the relationship is defined (constraints, relationship tests, or `fk_target_table`/`fk_target_field` meta) — is remapped to show `campaign_name` instead of the raw id, no per-key annotation needed. Only one column per table may be the display field; if several are marked, the first is used.
+
+This sets the field's [dimension](https://www.metabase.com/docs/latest/data-modeling/metadata-editing#remap-a-fields-display-values) (`type: external`), which is independent of the foreign key relationship itself. Run `dbt-metabase models` after the target column exists in Metabase, since the remapping references it.
+
 ### Semantic Types
 
 Now that we have foreign keys configured, let's tell Metabase that `email` column contains email addresses:

--- a/dbtmetabase/_models.py
+++ b/dbtmetabase/_models.py
@@ -65,8 +65,14 @@ class ModelsMixin(metaclass=ABCMeta):
         if not database:
             raise MetabaseStateError(f"Database not found: {metabase_database}")
 
+        # Display fields are read from the full manifest, not the filtered set: a
+        # foreign key may point at a table that filtering excluded from export, but
+        # its declared display field is still needed to remap the pointing column.
+        all_models = self.manifest.read_models()
+        display_fields = _build_display_fields(all_models)
+
         models = _filtered_models(
-            models=self.manifest.read_models(),
+            models=all_models,
             database_filter=database_filter,
             schema_filter=schema_filter,
             model_filter=model_filter,
@@ -96,6 +102,7 @@ class ModelsMixin(metaclass=ABCMeta):
             success &= self._export_model(
                 ctx=ctx,
                 model=model,
+                display_fields=display_fields,
                 append_tags=append_tags,
                 docs_url=docs_url,
                 order_fields=order_fields,
@@ -117,6 +124,11 @@ class ModelsMixin(metaclass=ABCMeta):
                     uid=update["id"],
                     body=update["body"],
                 )
+            elif update["kind"] == "field_dimension":
+                self.metabase.update_field_dimension(
+                    uid=update["id"],
+                    body=update["body"]["dimension"],
+                )
 
             _logger.info(
                 "%s '%s' updated successfully: %s",
@@ -132,6 +144,7 @@ class ModelsMixin(metaclass=ABCMeta):
         self,
         ctx: _Context,
         model: Model,
+        display_fields: Mapping[str, str],
         append_tags: bool,
         docs_url: str | None,
         order_fields: bool,
@@ -215,6 +228,7 @@ class ModelsMixin(metaclass=ABCMeta):
                 ctx,
                 table_key=table_key,
                 column=column,
+                display_fields=display_fields,
             )
 
         if order_fields:
@@ -290,6 +304,7 @@ class ModelsMixin(metaclass=ABCMeta):
         ctx: _Context,
         table_key: str,
         column: Column,
+        display_fields: Mapping[str, str] | None = None,
     ) -> bool:
         """Exports one dbt column to Metabase database schema."""
 
@@ -321,6 +336,7 @@ class ModelsMixin(metaclass=ABCMeta):
             fk_target_field_label = f"{fk_target_table_name}.{fk_target_field_name}"
 
             if fk_target_table_name and fk_target_field_name:
+                fk_target_table_key = fk_target_table_name
                 fk_target_field = ctx.get_field(
                     table_key=fk_target_table_name,
                     field_key=fk_target_field_name,
@@ -329,8 +345,9 @@ class ModelsMixin(metaclass=ABCMeta):
                 # Fallback for multi-database connections: try database.schema.table format
                 if not fk_target_field and fk_target_table_name.count(".") < 2:
                     table_database = table_key.split(".")[0]
+                    fk_target_table_key = f"{table_database}.{fk_target_table_name}"
                     fk_target_field = ctx.get_field(
-                        table_key=f"{table_database}.{fk_target_table_name}",
+                        table_key=fk_target_table_key,
                         field_key=fk_target_field_name,
                     )
 
@@ -347,6 +364,18 @@ class ModelsMixin(metaclass=ABCMeta):
                             change={semantic_type_key: "type/PK"},
                             label=fk_target_field_label,
                         )
+
+                    # If the target table declares a display field, remap this
+                    # foreign key to show that column instead of the raw id.
+                    self._export_column_dimension(
+                        ctx=ctx,
+                        column_label=column_label,
+                        fk_field=api_field,
+                        target_table_key=fk_target_table_key,
+                        display_field_name=(display_fields or {}).get(
+                            fk_target_table_name
+                        ),
+                    )
                 else:
                     _logger.error(
                         "Field '%s' referenced as foreign key '%s' not found",
@@ -429,6 +458,70 @@ class ModelsMixin(metaclass=ABCMeta):
 
         return success
 
+    def _export_column_dimension(
+        self,
+        ctx: _Context,
+        column_label: str,
+        fk_field: Mapping,
+        target_table_key: str,
+        display_field_name: str | None,
+    ):
+        """Remaps a foreign key's display value to the target table's display field.
+
+        Metabase calls this a field "dimension" (POST /api/field/:id/dimension); it
+        is independent of ``fk_target_field_id`` and controls which column is shown in
+        place of the raw id in tables and dashboards.
+        """
+
+        if not display_field_name:
+            return
+
+        display_field = ctx.get_field(target_table_key, display_field_name.upper())
+        if not display_field:
+            _logger.warning(
+                "Display field '%s.%s' for foreign key '%s' not found, skipping remapping",
+                target_table_key,
+                display_field_name,
+                column_label,
+            )
+            return
+
+        display_field_id = display_field.get("id")
+
+        # Metabase returns dimensions as a list (newer) or a single object (older).
+        dimensions = fk_field.get("dimensions") or []
+        if isinstance(dimensions, Mapping):
+            dimensions = [dimensions]
+        already_set = any(
+            d.get("human_readable_field_id") == display_field_id for d in dimensions
+        )
+        if already_set:
+            _logger.info(
+                "Field '%s' already shows '%s.%s'",
+                column_label,
+                target_table_key,
+                display_field_name,
+            )
+            return
+
+        ctx.update(
+            entity={"kind": "field_dimension", "id": fk_field["id"]},
+            change={
+                "dimension": {
+                    "type": "external",
+                    "name": display_field.get("display_name") or display_field_name,
+                    "human_readable_field_id": display_field_id,
+                }
+            },
+            label=column_label,
+        )
+        _logger.info(
+            "Field '%s' will be remapped to show '%s.%s'",
+            column_label,
+            target_table_key,
+            display_field_name,
+        )
+
 
 @dc.dataclass
 class _Context:
@@ -452,6 +545,32 @@ class _Context:
         update["body"] = body
 
         self.updates[key] = update
+
+
+def _build_display_fields(models: Iterable[Model]) -> Mapping[str, str]:
+    """Maps 'SCHEMA.TABLE' -> display column name for models declaring a display field.
+
+    A column is a display field when it carries `meta.metabase.display_field: true`.
+    Foreign keys pointing at the table are remapped to show that column.
+    """
+
+    display_fields: MutableMapping[str, str] = {}
+    for model in models:
+        table_key = f"{model.schema.upper()}.{model.alias.upper()}"
+        for column in model.columns:
+            if not column.display_field:
+                continue
+            if table_key in display_fields:
+                _logger.warning(
+                    "Table '%s' has multiple display fields ('%s' and '%s'), keeping the first",
+                    table_key,
+                    display_fields[table_key],
+                    column.name,
+                )
+                continue
+            display_fields[table_key] = column.name
+
+    return display_fields
 
 
 def _filtered_models(

--- a/dbtmetabase/manifest.py
+++ b/dbtmetabase/manifest.py
@@ -31,6 +31,7 @@ _COLUMN_META_FIELDS = _COMMON_META_FIELDS + [
     "number_style",
     "decimals",
     "currency",
+    "display_field",
 ]
 # Must be covered by Model attributes
 _MODEL_META_FIELDS = _COMMON_META_FIELDS + [
@@ -396,6 +397,11 @@ class Column:
     number_style: str | None = None
     decimals: int | None = None
     currency: str | None = None
+
+    # Marks this column as the human-readable "display field" for its table: any
+    # foreign key pointing at this table has its Metabase dimension remapped to
+    # show this column instead of the raw id.
+    display_field: bool | None = None
 
     fk_target_table: str | None = None
     fk_target_field: str | None = None

--- a/dbtmetabase/metabase.py
+++ b/dbtmetabase/metabase.py
@@ -221,3 +221,7 @@ class Metabase:
     def update_field(self, uid: str, body: Mapping) -> Mapping:
         """Posts an update to an existing table field."""
         return dict(self._api("put", f"/api/field/{uid}", json=body))
+
+    def update_field_dimension(self, uid: str, body: Mapping) -> Mapping:
+        """Sets the display-value remapping (dimension) on an existing field."""
+        return dict(self._api("post", f"/api/field/{uid}/dimension", json=body))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from dbtmetabase._models import _build_tables, _Context
+from dbtmetabase._models import _build_display_fields, _build_tables, _Context
 from dbtmetabase.manifest import Column, Group, Model
 from tests._mocks import MockDbtMetabase
 
@@ -279,3 +279,132 @@ def test_multi_database_foreign_key_resolution():
 
     field = ctx.get_field("MY_DATABASE.SILVER.ORDERS", "USER_ID")
     assert field["id"] == 2
+
+
+def test_build_display_fields():
+    """Columns marked with display_field build a SCHEMA.TABLE -> column map."""
+
+    models = [
+        Model(
+            database="db",
+            schema="public",
+            group=Group.nodes,
+            name="customers",
+            alias="customers",
+            columns=[
+                Column(name="customer_id"),
+                Column(name="first_name", display_field=True),
+            ],
+        ),
+    ]
+
+    assert _build_display_fields(models) == {"PUBLIC.CUSTOMERS": "first_name"}
+
+
+def test_export_column_display_field_dimension(core: MockDbtMetabase):
+    """A foreign key whose target declares a display field gets a dimension remap."""
+
+    ctx = _Context()
+    ctx.tables = {
+        "PUBLIC.ORDERS": {
+            "fields": {
+                "CUSTOMER_ID": {
+                    "kind": "field",
+                    "id": 10,
+                    "name": "customer_id",
+                    "fk_target_field_id": None,
+                    "dimensions": [],
+                },
+            },
+        },
+        "PUBLIC.CUSTOMERS": {
+            "fields": {
+                "CUSTOMER_ID": {
+                    "id": 1,
+                    "name": "customer_id",
+                    "semantic_type": "type/PK",
+                },
+                "FIRST_NAME": {
+                    "id": 2,
+                    "name": "first_name",
+                    "display_name": "First Name",
+                },
+            },
+        },
+    }
+
+    column = Column(
+        name="customer_id",
+        semantic_type="type/FK",
+        fk_target_table="PUBLIC.CUSTOMERS",
+        fk_target_field="customer_id",
+    )
+
+    assert core._export_column(
+        ctx,
+        table_key="PUBLIC.ORDERS",
+        column=column,
+        display_fields={"PUBLIC.CUSTOMERS": "first_name"},
+    )
+
+    dimension_updates = [
+        u for u in ctx.updates.values() if u["kind"] == "field_dimension"
+    ]
+    assert len(dimension_updates) == 1
+    update = dimension_updates[0]
+    assert update["id"] == 10
+    dimension = update["body"]["dimension"]
+    assert dimension == {
+        "type": "external",
+        "name": "First Name",
+        "human_readable_field_id": 2,
+    }
+
+
+def test_export_column_display_field_dimension_already_set(core: MockDbtMetabase):
+    """No dimension update is queued when the remapping already points at the target."""
+
+    ctx = _Context()
+    ctx.tables = {
+        "PUBLIC.ORDERS": {
+            "fields": {
+                "CUSTOMER_ID": {
+                    "kind": "field",
+                    "id": 10,
+                    "name": "customer_id",
+                    "fk_target_field_id": 1,
+                    "dimensions": [{"human_readable_field_id": 2}],
+                },
+            },
+        },
+        "PUBLIC.CUSTOMERS": {
+            "fields": {
+                "CUSTOMER_ID": {
+                    "id": 1,
+                    "name": "customer_id",
+                    "semantic_type": "type/PK",
+                },
+                "FIRST_NAME": {
+                    "id": 2,
+                    "name": "first_name",
+                    "display_name": "First Name",
+                },
+            },
+        },
+    }
+
+    column = Column(
+        name="customer_id",
+        semantic_type="type/FK",
+        fk_target_table="PUBLIC.CUSTOMERS",
+        fk_target_field="customer_id",
+    )
+
+    assert core._export_column(
+        ctx,
+        table_key="PUBLIC.ORDERS",
+        column=column,
+        display_fields={"PUBLIC.CUSTOMERS": "first_name"},
+    )
+
+    assert not [u for u in ctx.updates.values() if u["kind"] == "field_dimension"]


### PR DESCRIPTION
## Motivation

`dbt-metabase models` sets `fk_target_field_id`, which draws the join relationship in Metabase's data model. But in tables and dashboards Metabase still shows the **raw foreign key id**. Which column is shown in its place is controlled by a separate Metabase resource — a field *dimension* (`POST /api/field/:id/dimension`) — that `schema.yml` had no way to express. Until now that gap had to be filled with a standalone post-sync script.

## What this adds

A `metabase.display_field` column meta marker. Set it once, on a model's human-readable column:

```yaml
- name: campaign_name
  config:
    meta:
      metabase.display_field: true
```

Every foreign key that resolves to that table — however the relationship was defined (constraints, relationship tests, or `fk_target_table`/`fk_target_field` meta) — has its dimension remapped to show `campaign_name` instead of the raw id. No per-key annotation is needed.

### Behavior details

- **Read from the full manifest**, not the filtered set: a foreign key can point at a table that a `--schema`/`--model` filter excluded from export, but its declared display field is still needed to remap the columns pointing at it.
- **Idempotent**: a dimension already pointing at the target field is left untouched.
- **One per table**: if several columns are marked, the first is used (with a warning).
- Reuses the existing batched-update mechanism via a new `field_dimension` update kind and `Metabase.update_field_dimension`.

## Changes

- `manifest.py`: recognize `metabase.display_field` (`Column.display_field`).
- `metabase.py`: `update_field_dimension()` → `POST /api/field/:id/dimension`.
- `_models.py`: build the display-field map, remap FK dimensions during column export, dispatch `field_dimension` updates.
- `README.md`: new "Display Values" section.
- `tests/test_models.py`: cover the map build and the apply/skip paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)